### PR TITLE
Synapse agent Syndi

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,11 @@ Nothing more is planned until after the Evaluation (below).
 
 ### Evaluation
 
-There are ideas for other helper workflows and functionality, but these are dependent on first round of the proof-of-concept feedback, in case this is not the right approach/the design needs to change significantly. 
-To inform whether this actually benefits data management work, we need to to evaluate the proof-of-concept in several ways. 
-We would have to ask a user, "How would you compare using this versus trying to accomplish **the same work goal** using a different workflow that": 
-1. *Doesn't incorporate* any LLM and does things manually, with custom scripting, or with some other non-AI app.
-2. Incorporates ChatGPT but via the default online chat interface.
-3. Incorporates LLM/multiple LLMs through a different custom interface/solution.
-
-There is also workflow-specific research needed. To be continued...
+Feedback is currently being gathered with curators who are being trained for integrating this into their workflows. 
+The comparisons will be between workflows that:
+1. *Doesn't incorporate* any LLM and does things manually, maybe with custom scripting, or with some other non-AI app.
+2. Incorporates generative AI but only via the default online chat interface.
+3. Incorporates generative AI through a different custom interface/solution.
 
 
 [^1]: https://mitsloan.mit.edu/ideas-made-to-matter/how-generative-ai-can-boost-highly-skilled-workers-productivity

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Everyone is a curator and could benefit from AI-assisted curation. This open-sou
 
 ### Usage
 
-With more power comes the need to be more "responsible". 
-Unlike interacting with an LLM in the default cloud interface provided by a model provider, the interface here will provide a more powerful infrastructure such as prompts and logic already optimized to project-specific workflows, direct API access to relevant systems (Synapse), local file and database system access, and other tools/agents to accomplish various tasks. But the infrastructure will also need to include guardrails.
+With more power comes more responsibility. 
+Unlike interacting with generative AI in the default web interface, the application infrastructure here includes prompts and logic already optimized to project-specific workflows, direct API access to relevant platforms (Synapse), the local file system, configured databases, and additional tools/agents to accomplish various tasks. This infrastructure will also need to include guardrails.
 
 Until this is released as a .jar, you do need some Clojure tooling. 
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ For the terminal:
 
 TBD. -->
 
-#### Demos / tutorials for various scenarios (WIP)
-
-Links and materials will be provided when these demos are available:
+#### Demos / tutorials for various scenarios
 
 - **Assisted curation workflow** - You are preparing some kind of data asset for Synapse (e.g. a dataset).
 - **Data model exploration and development** - You want to develop your DCC-specific model with the benefit of analytical capabilities and accessible context with other DCC models (to reuse concepts, maintain alignment, improve quality, etc.) 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Our current target users are data professionals.
 
 ### Motivation
 
-### For biomedical curators/data managers
+#### For biomedical curators/data managers
 
 Research communities supported by dedicated data curators/managers receive the benefit of having data packaged and disseminated optimally for reuse. 
 Data managers themselves could benefit from tooling to facilitate their important and hard work of curating data, developing the data model, and facilitating data sharing in general. 
@@ -21,7 +21,7 @@ This is such an application. Some data management responsibilities[^2][^3] prior
 4. Facilitate data analysis/reuse and reporting for stakeholders, regulatory authorities, etc. 
 5. Oversee the integration of apps/new technologies and initiatives into data standards and structures. 
 
-<!-- ### And for everyone
+<!-- #### And for everyone
 
 Everyone is a curator and could benefit from AI-assisted curation. This open-source application originally developed for biomedical data curation is actually quite reusable for other domains and personal use cases. Some "off-label" use cases will be demonstrated. -->
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ The **web UI is highly recommended**:
 For the terminal:
 - `lein run -m agents.syndi`
 
-##### For personal knowledge curation 
+<!--  ##### For personal knowledge curation 
 
-TBD.
+TBD. -->
 
 #### Demos / tutorials for various scenarios (WIP)
 

--- a/README.md
+++ b/README.md
@@ -3,30 +3,28 @@
 > [!WARNING]  
 > This is a **prototype** application.
 > Development is still working mitigating risks of using generative AI. 
-Our current target users are Sage staff or other data professionals, not (yet) general Synapse users.   
-
+Our current target users are data professionals.   
 
 ### Motivation
 
-Research communities supported by dedicated data managers receive the benefit of having data packaged and disseminated optimally. 
+### For biomedical curators/data managers
+
+Research communities supported by dedicated data curators/managers receive the benefit of having data packaged and disseminated optimally for reuse. 
 Data managers themselves could benefit from tooling to facilitate their important and hard work of curating data, developing the data model, and facilitating data sharing in general. 
 And like with other knowledge work, including AI could greatly boost productivity, though it is perhaps best achieved through an internal or "wrapper" interface that mitigate pitfalls[^1]. 
 > Developers can also help with figuring out where AI can be inserted into workflows and how to design technology for doing that. 
 
-This is the proof-of-concept for such an application. 
-
-The design considered the different responsibilities of a data manager and if/how each can be prioritized for an assisted workflow. 
-There are many responsibilities[^2][^3], but the general list can be refined and ranked based on the work at Sage: 
-1. Data curation -- create, organize, QC, and publish data assets to the best advantage. 
+This is such an application. Some data management responsibilities[^2][^3] prioritized for an assisted workflow are: 
+1. Data curation -- create, organize, QC, and publish FAIR/harmonized data assets to the best advantage. 
 2. Develop standards and data models. 
 3. Maintain data management plans and SOPs. 
 4. Facilitate data analysis/reuse and reporting for stakeholders, regulatory authorities, etc. 
 5. Oversee the integration of apps/new technologies and initiatives into data standards and structures. 
 
+<!-- ### And for everyone
 
-**To be clear, the Assisted Curation/Content ENhancement Tool is a proof-of-concept CLI tool only focuses on helping with the first two responsibilities.** 
-In its first iteration, ACCENT narrows down the scope of the curation assistance even further, to dataset curation for the NF-OSI use case. 
-The idea is to work out the "wrapper" interface into a usable and productive workflow first. 
+Everyone is a curator and could benefit from AI-assisted curation. This open-source application originally developed for biomedical data curation is actually quite reusable for other domains and personal use cases. Some "off-label" use cases will be demonstrated. -->
+
 
 ### Usage
 
@@ -61,17 +59,22 @@ Tip for usage: Trying to reduce costs by switching to a cheaper model for some t
   - To use, must have `ANTHROPIC_API_KEY` in env or set in config.
   - The default model is Claude Sonnet 3.5.
 
-#### Run your preferred UI
+#### Run your preferred UI and specialized curation agent
 
 > [!NOTE]  
 > Currently, there are some tradeoffs between the terminal vs web UI. The web UI will have some features that the terminal will not, such as showing figures. On the other hand, web UI only works with OpenAI for now.
 
-For the terminal:
-- `lein run -m accent.chat`
+##### For Synapse curation
 
-For the web UI:
+The **web UI is highly recommended**:
 - `lein run -m accent.app`
-- Go to http://localhost:3000
+
+For the terminal:
+- `lein run -m agents.syndi`
+
+##### For personal knowledge curation 
+
+TBD.
 
 #### Demos / tutorials for various scenarios (WIP)
 

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -1,9 +1,6 @@
 (ns accent.chat
   (:gen-class)
   (:require [accent.state :refer [setup u]]
-            [curate.dataset :refer [syn curate-dataset get-table-column-models query-table]]
-            [database.dlvn :refer [show-reference-schema ask-knowledgegraph get-portal-dataset-props as-schema]]
-            [agents.extraction :refer [call-extraction-agent call_extraction_agent_spec]]
             [babashka.http-client :as client]
             [cheshire.core :as json]
             [clojure.string :as str]
@@ -118,94 +115,6 @@
           first-choice (first (:choices parsed-body))]
       (get-in first-choice [:message :content]))))
 
-;;;;;;;;;;;;;;;;;;;;;;
-;; Tool call wrappers
-;;;;;;;;;;;;;;;;;;;;;;
-
-(defn wrap-curate-dataset
-  [args]
-  (let [scope (args :scope_id)
-        asset-view (@u :asset-view)
-        dataset-props (get-portal-dataset-props)]
-    {:result (str (curate-dataset @syn scope asset-view dataset-props))
-     :type   :success}))
-
-(defn wrap-enhance-curation
-  [args]
-  {:result "Successful update."
-   :type   :success})
-
-(defn wrap-ask-knowledgegraph
-  [args]
-  {:result (->> (ask-knowledgegraph (args :query))
-                (mapcat identity)
-                (vec)
-                (str/join ", "))
-   :type   :success})
-
-(defn wrap-get-queryable-fields
-  [{:keys [table_id] :or {table_id (@u :asset-view)}}]
-  (let [cols (get-table-column-models @syn table_id)
-        table-schema (as-schema cols (@u :dcc))]
-    {:result (str table-schema)
-     :type   :success}))
-
-(defn wrap-ask-table
-  [{:keys [table_id query]}]
-  {:result (->> (query-table @syn table_id query)
-                (str))
-   :type   :success})
-
-(defn wrap-call-extraction-agent
-  [{:keys [input input_representation json_schema json_schema_representation]}] 
-  (-> (call-extraction-agent input input_representation json_schema json_schema_representation) 
-      (request-openai-completions :string) 
-      (get-first-message-content)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Custom tool time
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn with-next-tool-call
-  "Applies logic for chaining certain tool calls. Input should be result from `tool-time`
-  Currently, enhance_curation should be forced after curate_dataset only under certain return types."
-  [tool-result]
-  (if (and (= "curate_dataset" (tool-result :tool)) (= :success (tool-result :type)))
-    (assoc tool-result :next-tool-call "enhance_curation")
-    tool-result))
-
-(defn tool-time 
-  [tool-call]
-  (let [call-fn (get-in tool-call [:function :name])
-        args    (json/parse-string (get-in tool-call [:function :arguments]) true)]
-    (try
-      (let [result (case call-fn
-                     "curate_dataset"         (wrap-curate-dataset args)
-                     "enhance_curation"       (wrap-enhance-curation args)
-                     "get_knowledgegraph_schema" {:result (show-reference-schema (args :schema_name))
-                                                  :type   :success}
-                     "ask_knowledgegraph"     (wrap-ask-knowledgegraph args)
-                     "get_queryable_fields"   (wrap-get-queryable-fields args)
-                     "ask_table"              (wrap-ask-table args)
-                     "call_extraction_agent"  (wrap-call-extraction-agent args)
-                     (throw (ex-info "Invalid tool function" {:tool call-fn})))]
-        (if (map? result)
-           (merge  {:tool call-fn} result)
-           {:tool call-fn :result result}))
-      (catch Exception e
-        {:tool   call-fn
-         :result (.getMessage e)
-         :type   :error
-         :error  true}))))
-
-(defn anthropic-tool-time
-  [tool-use]
-  (let [tool-call {:id       (:id tool-use)
-                   :type     "function"
-                   :function {:name      (:name tool-use)
-                              :arguments (json/generate-string (:input tool-use))}}]
-    (tool-time tool-call)))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper Fns for Streaming
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -274,9 +183,10 @@
                         (cond->
                         {:model model
                          :messages @messages
-                         :tools tools
+                         ;;:tools tools
                          :parallel_tool_calls false
                          :stream (@u :stream)}
+                         tools (assoc :tools tools) 
                          tool-choice (assoc :tool_choice {:type "function" :function {:name tool-choice}}))
                        (request-openai-completions))]
          (if (:error response)
@@ -287,7 +197,7 @@
   (add-tool-result [this tool-calls clients]
     (let [tool-call   (first tool-calls)
           tool-name   (get-in tool-call [:function :name])
-          result      (with-next-tool-call (tool-time tool-call))
+          result      (tool-time tool-call)
           forced-tool (result :next-tool-call)
           msg         {:tool_call_id (tool-call :id)
                        :role         "tool"
@@ -379,7 +289,7 @@
           response))))
    (add-tool-result [this tool-use] (add-tool-result this tool-use nil))
    (add-tool-result [this tool-use clients]
-                    (let [result (with-next-tool-call (tool-time tool-use))
+                    (let [result (tool-time tool-use)
                           msg    {:role    "user"
                                   :content [{:type        "tool_result"
                                              :tool_use_id (tool-use :id)
@@ -391,106 +301,24 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;
-;; Tool defs
+;; Tools
 ;;;;;;;;;;;;;;;;;;;;;
 
-(def curate_dataset_spec
-  {:type "function"
-   :function
-   {:name "curate_dataset"
-    :description "Use this to help user curate a dataset on the Synapse platform given a scope id and, optionally, a manifest id."
-    :parameters
-    {:type "object"
-     :properties
-     {:scope_id
-      {:type "string"
-       :description "The scope id to use, e.g. 'syn12345678'"}
-      :manifest_id
-      {:type "string"
-       :description (str "The manifest id, e.g. 'syn224466889'."
-                         "While the manifest can be automatically discovered in most cases,"
-                         " when not in the expected location the id should be provided.")}}}
-    :required ["scope_id"] }})
+(defn tool-time
+  [tool-call]
+  (let [call-fn (get-in tool-call [:function :name])
+        args    (json/parse-string (get-in tool-call [:function :arguments]) true)] 
+        {:tool   call-fn
+         :result "Tools are not implemented in vanilla chat."
+         :error  false}))
 
-(def get_knowledgegraph_schema_spec
-  {:type "function"
-   :function
-   {:name "get_knowledgegraph_schema"
-    :description (str "Retrieve the knowledgegraph schemas in order to help construct a correct query for the user question."
-                      "Then use ask_knowledgegraph with the constructed query.")
-    :parameters
-    {:type "object"
-     :properties
-     {:schema_name
-      {:type "string"
-       :enum ["data-model" "schematic-config" "dcc"]
-       :description "Name of the desired schema to bring up for reference."}}}
-     :required []
-     }})
-
-(def ask_knowledgegraph_spec
-  {:type "function"
-   :function
-   {:name "ask_knowledgegraph"
-    :description (str "Query knowledgegraph on the user's behalf to answer questions about different centers' reference data models, app configurations, and assets."
-                      "Always base queries on the knowledgegraph schema reference returned by get_knowledgegraph_schema. "
-                      "Input should be a valid Datomic query.")
-    :parameters
-    {:type "object"
-     :properties
-     {:query
-      {:type "string"
-       :description (str "Datomic query extracting info to answer the user's question."
-                         "Datomic query should be written as plain text using the database schema.")}}
-     :required ["query"]}}})
-
-(def enhance_curation_spec
-  {:type "function"
-   :function
-   {:name "enhance_curation"
-    :description "Given features and related content about an entity, derive additional properties."
-    :parameters
-    {:type "object"
-     :properties
-     {:title {:type "string"
-              :description "A publishable title for the entity given its features and what's present about it"}
-      :description {:type "string"
-                    :description "Helpful summary for entity no more than a paragraph long."}
-      :other {:type "object"
-              :description "Any additional properties and values. Use only properties mentioned."}
-      }
-     :required ["title" "description"] }}})
-
-(def get_queryable_fields_spec
-  {:type "function"
-   :function
-   {:name "get_queryable_fields"
-    :description (str "Use this to confirm the availability of a Synapse table id and its queryable fields to help answer user questions. "
-                      "In some cases, the available fields may not be sufficient for the question. "
-                      "Use the result to construct a query for ask_synapse or explain why the question cannot be answered.")
-    :parameters
-    {:type "object"
-     :properties
-     {:table_id
-      {:type "string"
-       :description (str "By default, use asset view for table id "
-                         "unless user provides another id.")}}}
-    :required ["table_id"]}})
-
-(def ask_table_spec
-  {:type "function"
-   :function
-   {:name "ask_table"
-    :description (str "Use to query table with SQL to help answer a user question; "
-                      "query should include only searchable fields;"
-                      "a subset of valid SQL is allowed -- do not include update clauses.")
-    :parameters
-    {:type "object"
-     :properties
-     {:table_id {:type "string"
-                 :description "Table id, e.g. 'syn5464523"}
-      :query {:type "string"
-              :description "A valid SQL query."}}}}})
+(defn anthropic-tool-time
+  [tool-use]
+  (let [tool-call {:id       (:id tool-use)
+                   :type     "function"
+                   :function {:name      (:name tool-use)
+                              :arguments (json/generate-string (:input tool-use))}}]
+    (tool-time tool-call)))
 
 (defn convert-tools-for-anthropic
   "Convert OpenAI tools schema to Anthropic tools schema"
@@ -502,17 +330,7 @@
                              (get-in [:function :parameters]))})
         openai-tools))
 
-(def tools
-  [curate_dataset_spec
-   get_knowledgegraph_schema_spec
-   ask_knowledgegraph_spec
-   enhance_curation_spec
-   get_queryable_fields_spec
-   ask_table_spec
-   call_extraction_agent_spec
-   ])
-
-(def anthropic-tools (convert-tools-for-anthropic tools))
+(def empty-tools nil)
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Models
@@ -551,13 +369,13 @@
 (def OpenAIChatAgent 
   (OpenAIProvider. "gpt-4o" 
                    openai-messages
-                   tools 
+                   empty-tools 
                    tool-time))
 
 (def AnthropicChatAgent 
   (AnthropicProvider. "claude-3-5-sonnet-latest" 
                       anthropic-messages
-                      anthropic-tools 
+                      empty-tools
                       anthropic-tool-time))
 
 (defn -main []

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -542,9 +542,9 @@
 ;; Vanilla chat
 ;;;;;;;;;;;;;;;;;;;;;
 
-(def init-prompt [{:role "system" :content "You are a helpful assistant."}])
+(def openai-init-prompt [{:role "system" :content "You are a helpful assistant."}])
 
-(def openai-messages (atom (init-prompt)))
+(def openai-messages (atom openai-init-prompt))
 
 (def anthropic-messages (atom []))
 

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -389,31 +389,6 @@
                   (let [msg (peek @messages)]
                     (assoc msg :content (get-in msg [:content 0 :text])))))
 
-;;;;;;;;;;;;;;;;;;;;;;
-;; Usage
-;;;;;;;;;;;;;;;;;;;;;;
-
-(defn system-prompt
-  []
-  (str "You are a helpful data management assistant for a data coordinating center (DCC). "
-       "Unless specified otherwise, your DCC is '" (@u :dcc) "' and your asset view has id " (@u :asset-view) "."
-       "You help users with searching and curating data on Synapse "
-       "and working with dcc-specific data dictionaries and configurations."))
-
-(defn init-prompt
-  []
-  [{:role    "system"
-    :content (system-prompt)}])
-
-(defn new-chat-openai!
-  "Initialize a new chat with OpenAI."
-  []
-  (atom (init-prompt)))
-
-(defn new-chat-anthropic!
-  "Initialize a new chat with Anthropic."
-  []
-  (atom []))
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;; Tool defs
@@ -540,10 +515,8 @@
 (def anthropic-tools (convert-tools-for-anthropic tools))
 
 ;;;;;;;;;;;;;;;;;;;;;
-;; Default chat
+;; Models
 ;;;;;;;;;;;;;;;;;;;;;
-
-;; MODELS
 
 (def openai-models
   "https://platform.openai.com/docs/models"
@@ -560,20 +533,30 @@
 (def anthropic-models
   "https://docs.anthropic.com/en/docs/about-claude/models"
   {:default "claude-3-5-sonnet-latest"
-   :models {"claude-3-5-sonnet-latest" {:label "Claude 3.5 Sonnet" 
+   :models {"claude-3-5-sonnet-latest" {:label "Claude 3.5 Sonnet"
                                         :context 200000}
             "claude-3-sonnet-20240229" {:label "Claude 3 Sonnet"
                                         :context 200000}}})
 
+;;;;;;;;;;;;;;;;;;;;;
+;; Vanilla chat
+;;;;;;;;;;;;;;;;;;;;;
+
+(def init-prompt [{:role "system" :content "You are a helpful assistant."}])
+
+(def openai-messages (atom (init-prompt)))
+
+(def anthropic-messages (atom []))
+
 (def OpenAIChatAgent 
   (OpenAIProvider. "gpt-4o" 
-                   (new-chat-openai!) 
+                   openai-messages
                    tools 
                    tool-time))
 
 (def AnthropicChatAgent 
   (AnthropicProvider. "claude-3-5-sonnet-latest" 
-                      (new-chat-anthropic!) 
+                      anthropic-messages
                       anthropic-tools 
                       anthropic-tool-time))
 

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -380,13 +380,13 @@
 
 (def anthropic-messages (atom [])) ;; system prompt is not in messages
 
-(def OpenAIChatAgent 
+(def OpenAIVanillaChat 
   (OpenAIProvider. "gpt-4o" 
                    openai-messages
                    nil 
                    tool-time))
 
-(def AnthropicChatAgent 
+(def AnthropicVanillaChat
   (AnthropicProvider. "claude-3-5-sonnet-latest" 
                       anthropic-messages 
                       nil
@@ -395,8 +395,8 @@
 (defn -main []
   (setup)
   (let [provider (if (= (@u :model-provider) "OpenAI") 
-                   OpenAIChatAgent
-                   AnthropicChatAgent)]
+                   OpenAIVanillaChat
+                   AnthropicVanillaChat)]
     (println "Chat initialized. Your message:") 
     (loop [prompt (read-line)]
       (let [ai-reply (->> prompt

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -233,7 +233,7 @@
   [{:role "system" 
     :content (str "You are a data professional who helps users manage and interact with data on the Synapse platform." 
                   "Your name is Syndi (pronounced like 'Cindy')."
-                  "To provide the best help, ask users about a data coordinating center (DCC) users may be affiliated with "
+                  "To provide the best help, ask users about a data coordinating center (DCC) they may be affiliated with "
                   "and proactively describe and offer to deploy tools at your disposal.")}])
 
 (def openai-messages (atom openai-init-prompt))

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -1,0 +1,246 @@
+(ns agents.syndi
+  (:gen-class)
+  (:require [accent.chat :refer [->OpenAIProvider ->AnthropicProvider convert-tools-for-anthropic]]
+            [curate.dataset :refer [syn curate-dataset get-table-column-models query-table]]
+            [database.dlvn :refer [show-reference-schema ask-knowledgegraph get-portal-dataset-props as-schema]]
+            [agents.extraction :refer [call-extraction-agent call_extraction_agent_spec]]
+            [babashka.http-client :as client]
+            [cheshire.core :as json]
+            [clojure.string :as str]
+            [clojure.java.io :as io]
+            [org.httpkit.server :as httpkit]
+            [com.brunobonacci.mulog :as mu]))
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Tool defs
+;;;;;;;;;;;;;;;;;;;;;
+
+(def curate_dataset_spec
+  {:type "function"
+   :function
+   {:name "curate_dataset"
+    :description "Use this to help user curate a dataset on the Synapse platform given a scope id and, optionally, a manifest id."
+    :parameters
+    {:type "object"
+     :properties
+     {:scope_id
+      {:type "string"
+       :description "The scope id to use, e.g. 'syn12345678'"}
+      :manifest_id
+      {:type "string"
+       :description (str "The manifest id, e.g. 'syn224466889'."
+                         "While the manifest can be automatically discovered in most cases,"
+                         " when not in the expected location the id should be provided.")}}}
+    :required ["scope_id"] }})
+
+(def get_knowledgegraph_schema_spec
+  {:type "function"
+   :function
+   {:name "get_knowledgegraph_schema"
+    :description (str "Retrieve the knowledgegraph schemas in order to help construct a correct query for the user question."
+                      "Then use ask_knowledgegraph with the constructed query.")
+    :parameters
+    {:type "object"
+     :properties
+     {:schema_name
+      {:type "string"
+       :enum ["data-model" "schematic-config" "dcc"]
+       :description "Name of the desired schema to bring up for reference."}}}
+     :required []
+     }})
+
+(def ask_knowledgegraph_spec
+  {:type "function"
+   :function
+   {:name "ask_knowledgegraph"
+    :description (str "Query knowledgegraph on the user's behalf to answer questions about different centers' reference data models, app configurations, and assets."
+                      "Always base queries on the knowledgegraph schema reference returned by get_knowledgegraph_schema. "
+                      "Input should be a valid Datomic query.")
+    :parameters
+    {:type "object"
+     :properties
+     {:query
+      {:type "string"
+       :description (str "Datomic query extracting info to answer the user's question."
+                         "Datomic query should be written as plain text using the database schema.")}}
+     :required ["query"]}}})
+
+(def enhance_curation_spec
+  {:type "function"
+   :function
+   {:name "enhance_curation"
+    :description "Given features and related content about an entity, derive additional properties."
+    :parameters
+    {:type "object"
+     :properties
+     {:title {:type "string"
+              :description "A publishable title for the entity given its features and what's present about it"}
+      :description {:type "string"
+                    :description "Helpful summary for entity no more than a paragraph long."}
+      :other {:type "object"
+              :description "Any additional properties and values. Use only properties mentioned."}
+      }
+     :required ["title" "description"] }}})
+
+(def get_queryable_fields_spec
+  {:type "function"
+   :function
+   {:name "get_queryable_fields"
+    :description (str "Use this to confirm the availability of a Synapse table id and its queryable fields to help answer user questions. "
+                      "In some cases, the available fields may not be sufficient for the question. "
+                      "Use the result to construct a query for ask_synapse or explain why the question cannot be answered.")
+    :parameters
+    {:type "object"
+     :properties
+     {:table_id
+      {:type "string"
+       :description (str "By default, use asset view for table id "
+                         "unless user provides another id.")}}}
+    :required ["table_id"]}})
+
+(def ask_table_spec
+  {:type "function"
+   :function
+   {:name "ask_table"
+    :description (str "Use to query table with SQL to help answer a user question; "
+                      "query should include only searchable fields;"
+                      "a subset of valid SQL is allowed -- do not include update clauses.")
+    :parameters
+    {:type "object"
+     :properties
+     {:table_id {:type "string"
+                 :description "Table id, e.g. 'syn5464523"}
+      :query {:type "string"
+              :description "A valid SQL query."}}}}})
+
+(def tools
+  [curate_dataset_spec
+   get_knowledgegraph_schema_spec
+   ask_knowledgegraph_spec
+   enhance_curation_spec
+   get_queryable_fields_spec
+   ask_table_spec
+   call_extraction_agent_spec
+   ])
+
+(def anthropic-tools (convert-tools-for-anthropic tools))
+
+;;;;;;;;;;;;;;;;;;;;;;
+;; Custom tool calls
+;;;;;;;;;;;;;;;;;;;;;;
+
+(defn wrap-curate-dataset
+  [args]
+  (let [scope (args :scope_id)
+        asset-view (@u :asset-view)
+        dataset-props (get-portal-dataset-props)]
+    {:result (str (curate-dataset @syn scope asset-view dataset-props))
+     :type   :success}))
+
+(defn wrap-enhance-curation
+  [args]
+  {:result "Successful update."
+   :type   :success})
+
+(defn wrap-ask-knowledgegraph
+  [args]
+  {:result (->> (ask-knowledgegraph (args :query))
+                (mapcat identity)
+                (vec)
+                (str/join ", "))
+   :type   :success})
+
+(defn wrap-get-queryable-fields
+  [{:keys [table_id] :or {table_id (@u :asset-view)}}]
+  (let [cols (get-table-column-models @syn table_id)
+        table-schema (as-schema cols (@u :dcc))]
+    {:result (str table-schema)
+     :type   :success}))
+
+(defn wrap-ask-table
+  [{:keys [table_id query]}]
+  {:result (->> (query-table @syn table_id query)
+                (str))
+   :type   :success})
+
+(defn wrap-call-extraction-agent
+  [{:keys [input input_representation json_schema json_schema_representation]}] 
+  (-> (call-extraction-agent input input_representation json_schema json_schema_representation) 
+      (request-openai-completions :string) 
+      (get-first-message-content)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Custom tool time
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn with-next-tool-call
+  "Applies logic for chaining certain tool calls. Input should be result from `tool-time`
+  Currently, enhance_curation should be forced after curate_dataset only under certain return types."
+  [tool-result]
+  (if (and (= "curate_dataset" (tool-result :tool)) (= :success (tool-result :type)))
+    (assoc tool-result :next-tool-call "enhance_curation")
+    tool-result))
+
+(defn tool-time 
+  [tool-call]
+  (let [call-fn (get-in tool-call [:function :name])
+        args    (json/parse-string (get-in tool-call [:function :arguments]) true)]
+    (try
+      (let [result (case call-fn
+                     "curate_dataset"         (wrap-curate-dataset args)
+                     "enhance_curation"       (wrap-enhance-curation args)
+                     "get_knowledgegraph_schema" {:result (show-reference-schema (args :schema_name))
+                                                  :type   :success}
+                     "ask_knowledgegraph"     (wrap-ask-knowledgegraph args)
+                     "get_queryable_fields"   (wrap-get-queryable-fields args)
+                     "ask_table"              (wrap-ask-table args)
+                     "call_extraction_agent"  (wrap-call-extraction-agent args)
+                     (throw (ex-info "Invalid tool function" {:tool call-fn})))]
+        (if (map? result)
+           (merge  {:tool call-fn} result)
+           {:tool call-fn :result result}))
+      (catch Exception e
+        {:tool   call-fn
+         :result (.getMessage e)
+         :type   :error
+         :error  true}))))
+
+(defn anthropic-tool-time
+  [tool-use]
+  (let [tool-call {:id       (:id tool-use)
+                   :type     "function"
+                   :function {:name      (:name tool-use)
+                              :arguments (json/generate-string (:input tool-use))}}]
+    (tool-time tool-call)))
+
+;;;;;;;;;;;;;;;;;;;;;
+;; Agent
+;;;;;;;;;;;;;;;;;;;;;
+
+(def OpenAIChatAgent 
+  (->OpenAIProvider "gpt-4o" 
+                   (new-chat-openai!) 
+                   tools 
+                   tool-time))
+
+(def AnthropicChatAgent 
+  (->AnthropicProvider "claude-3-5-sonnet-latest" 
+                      (new-chat-anthropic!) 
+                      anthropic-tools 
+                      anthropic-tool-time))
+
+(defn -main []
+  (setup)
+  (let [provider (if (= (@u :model-provider) "OpenAI") 
+                   OpenAIChatAgent
+                   AnthropicChatAgent)]
+    (println "Chat initialized. Your message:") 
+    (loop [prompt (read-line)]
+      (let [ai-reply (->> prompt
+                         (prompt-ai provider)
+                         (parse-response provider))]
+        (println "accent:" (ai-reply :content))
+        (when-not (:final ai-reply)
+          (print "user: ")
+          (flush)
+          (recur (read-line)))))))

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -196,9 +196,9 @@
                      "ask_table"              (wrap-ask-table args)
                      "call_extraction_agent"  (wrap-call-extraction-agent args)
                      (throw (ex-info "Invalid tool function" {:tool call-fn})))]
-        (if (map? result)
-           (merge  {:tool call-fn} result)
-           {:tool call-fn :result result}))
+        (->
+         (if (map? result) (merge  {:tool call-fn} result) {:tool call-fn :result result})
+         (with-next-tool-call))
       (catch Exception e
         {:tool   call-fn
          :result (.getMessage e)

--- a/src/server/core.clj
+++ b/src/server/core.clj
@@ -1,7 +1,8 @@
 (ns server.core
   (:gen-class)
   (:require [accent.state :refer [setup u]]
-            [accent.chat :refer [stream-response OpenAIChatAgent]]
+            [accent.chat :refer [stream-response]]
+            [agents.syndi :refer [OpenAISyndiAgent]]
             [org.httpkit.server :as httpkit]
             [compojure.core :refer [defroutes GET]]
             [compojure.route :as route]
@@ -37,7 +38,7 @@
         ;; (httpkit/send! channel (json/generate-string {:type "dcc_set" :dcc (:dcc parsed-msg)})))
 
       "chat"
-      (future (stream-response OpenAIChatAgent (:content parsed-msg) nil clients))
+      (future (stream-response OpenAISyndiAgent (:content parsed-msg) nil clients))
 
       (httpkit/send! channel (json/generate-string {:type "error" :message "Unknown message type"})))))
 


### PR DESCRIPTION
Related to #73. Implements more refactoring and creation of Synapse agent named Syndi (`agents/syndi`) on top of a new "vanilla" chat agent. Re-engineered prompt for Syndi. 

As tested, `lein run -m accent.chat` now runs the vanilla chat agent in the console, while `lein run -m agents.syndi` starts interaction specifically with Syndi in the console. However, `lein run -m accent.app` still defaults to Syndi. In the future, the app will have an option to choose from among different assistant agents/personas. 