### PR TITLE
Enable o3-mini

### DIFF
--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -179,12 +179,13 @@
                     (as-user-message content)
                     content)]
       (swap! messages conj message)
-      (let [response (->
+      (let [tools (if (= "o3-mini") {:tools tools} {:tools tools :parallel_tool_calls false})
+            response (->
                       (cond->
                        {:model model
                         :messages @messages
                         :stream (@u :stream)}
-                       tools (merge {:tools tools :parallel_tool_calls false})
+                       tools (merge tools)
                        tool-choice (assoc :tool_choice {:type "function" :function {:name tool-choice}}))
                       (request-openai-completions))]
         (if (:error response)

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -338,6 +338,13 @@
                    tool-time
                    meta))
 
+(def OpenAISyndiReasoningAgent 
+  (chat/->OpenAIProvider "o3-mini" 
+                   openai-messages
+                   tools 
+                   tool-time
+                   meta))
+
 (def AnthropicSyndiAgent 
   (chat/->AnthropicProvider "claude-3-7-sonnet-latest" 
                       anthropic-messages


### PR DESCRIPTION
Make o3-mini available, but _do not_ make it the default Syndi agent when using OpenAI as provider. 