### PR TITLE
Tools registry implementation

### DIFF
--- a/DESIGN.gv
+++ b/DESIGN.gv
@@ -2,42 +2,52 @@ digraph G {
  
   rankdir=BT;
   
-  subgraph cluster_dm_rag {
+  subgraph cluster_db {
       
-    db[label="database.dlvn"];
+    db_dlvn[label="database.dlvn"];
     db_up[label="database.upstream"];
-    db -> db_up
+    db_dlvn -> db_up
+    db_arachne[label="database.arachne"]
     
       
   }
   
-  subgraph cluster_ui {
+ 
+  subgraph cluster_resources {
       
-    vegalite[label="accent.viz.vegalite"]
-     web[label="accent.ui.web"]
-     vegalite -> web
-    
-  }
-  
-  subgraph cluster_curate {
-      
-    curate_dataset[label="curate.dataset"];
-    curate_tool[label="curate.tool"];    
+    tools[label="accent.tools"]  
+    tools_synapse[label="tools.synapse"];
+    tools_local_db[label="tools.local_databases"];
+    tools -> tools_synapse
+    tools -> tools_local_db
+    tools_local_db -> db_dlvn
+    tools_local_db -> db_arachne
       
   }
   
   subgraph cluster_accent {
     
-    state[label="accent.state"]    
-    state -> db
-    state -> curate_dataset
+    state[label="accent.state"]
        
-     chat -> state
-     chat[label="accent.chat"]
-     chat -> curate_dataset
-     chat -> db
-     chat -> vegalite
-     
+    registry[label="accent.registry"]
+    tools -> registry
+    agent -> tools   
+    agent -> state
+    agent[label="accent.agent"]
+   
+    
+  }
+  
+  subgraph cluster_server {
+      
+      server_mcp[label="server.mcp"]
+      server_mcp -> registry
+  }
+  
+  subgraph cluster_agents {
+      Syndi -> agent
+      Arachne -> agent
+      Extraction -> agent
   }
 
 }

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/data.csv {:mvn/version "1.1.0"}
         cheshire/cheshire {:mvn/version "5.13.0"}
         org.clojars.huahaiy/datalevin-native {:mvn/version "0.9.1"}
@@ -13,6 +13,7 @@
         org.apache.tika/tika-core {:mvn/version "2.8.0"}
         org.apache.tika/tika-parsers-standard-package {:mvn/version "2.8.0"}
         arachne-framework/aristotle {:git/url "https://github.com/arachne-framework/aristotle" :git/sha "d7ee879945e0060dc5fcd0b8eac2e0e476d066d7"}
+        metosin/malli {:mvn/version "0.18.0"}
         io.github.swirrl/csv2rdf {:git/url "https://github.com/Swirrl/csv2rdf.git"
                                    :git/tag "v0.7.1"
                                    :git/sha "a814243"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/data.csv {:mvn/version "1.1.0"}
         cheshire/cheshire {:mvn/version "5.13.0"}
         org.clojars.huahaiy/datalevin-native {:mvn/version "0.9.1"}

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -1,7 +1,7 @@
 (ns accent.chat
   (:gen-class)
   (:require [accent.state :refer [setup u]]
-            [accent.registry :refer [tools->openai-format tools->anthropic-format create-tool-dispatcher create-anthropic-tool-dispatcher]]
+            [accent.registry :refer [select-tools create-tool-dispatcher create-anthropic-tool-dispatcher]]
             [babashka.http-client :as client]
             [cheshire.core :as json]
             [clojure.string :as str]
@@ -168,7 +168,7 @@
   AIProviderOps
   (parse-response [this resp] (parse-response this resp nil))
   (parse-response [this resp clients]
-    (if (:error resp)
+    (if (:isError resp)
       (do
         (println "Error occurred:" (:message resp))
         {:role    "system"
@@ -279,7 +279,7 @@
   (parse-response [this resp clients]
     (if (:isError resp)
       (do
-        (mu/log ::error :data response)
+        (mu/log ::error :data resp)
         {:role    "system"
          :content (str "An error occurred: " (resp :message))})
       (let [resp       (json/parse-string (:body resp) true)
@@ -371,20 +371,19 @@
   [agent-config & {:keys [context] :or {context (atom {})}}]
   (let [provider (:provider agent-config)
         model (:model agent-config)
-        role (:role agent-config)]
+        role (:role agent-config)
+        tool-set (:tools agent-config)]
     (case provider
       :openai (OpenAIProvider. model
                                (atom [{:role "system" :content role}])
-                               (tools->openai-format tool-set) 
+                               (select-tools tool-set :openai)
                                (create-tool-dispatcher tool-set)
                                context)
       :anthropic (AnthropicProvider. model
                                      (atom [])
-                                     (tools->anthropic-format tool-set)
-                                     (create-anthropic-tool-dispatcher tool-set) 
-                                     (swap! context assoc :system role))
-      )))
-
+                                     (select-tools tool-set :anthropic)
+                                     (create-anthropic-tool-dispatcher tool-set)
+                                     (swap! context assoc :system role)))))
 
 ;; =============================================================================
 ;; Basic Chat Access to Agent

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -24,7 +24,9 @@
 
 (defprotocol AgentOps
   (get-model [this] "Get current model")
-  (switch-model [this model] "Switch to given model"))
+  (switch-model [this model] "Switch to given model")
+  (show-tools [this] "Show the tools agent currently sees")
+  (get-context [this] "Get context that agent has access to"))
 
 ;;=========================================
 ;; Utils
@@ -262,7 +264,9 @@
   
   AgentOps
   (get-model [this] model)
-  (switch-model [this new-model] (set! model new-model)))
+  (switch-model [this new-model] (set! model new-model))
+  (show-tools [this] tools)
+  (get-context [this] @context))
 
 ;;=====================================================
 ;; Anthropic Provider Def
@@ -335,8 +339,9 @@
   
   AgentOps
   (get-model [this] model)
-  (switch-model [this new-model] (set! model new-model)))
-
+  (switch-model [this new-model] (set! model new-model))
+  (show-tools [this] tools)
+  (get-context [this] @context))
 
 ;;==========================================
 ;; Models
@@ -368,7 +373,7 @@
 
 (defn create-agent
   "Create an agent, possibly endowed with tools, using config and optional add'l context"
-  [agent-config & {:keys [context] :or {context (atom {})}}]
+  [agent-config & {:keys [context]}]
   (let [provider (:provider agent-config)
         model (:model agent-config)
         role (:role agent-config)
@@ -378,12 +383,12 @@
                                (atom [{:role "system" :content role}])
                                (select-tools tool-set :openai)
                                (create-tool-dispatcher tool-set)
-                               context)
+                               (if context context (atom {})))
       :anthropic (AnthropicProvider. model
                                      (atom [])
                                      (select-tools tool-set :anthropic)
                                      (create-anthropic-tool-dispatcher tool-set)
-                                     (swap! context assoc :system role)))))
+                                     (if context context (atom {:system role}))))))
 
 ;; =============================================================================
 ;; Basic Chat Access to Agent

--- a/src/accent/chat.clj
+++ b/src/accent/chat.clj
@@ -1,6 +1,7 @@
 (ns accent.chat
   (:gen-class)
   (:require [accent.state :refer [setup u]]
+            [accent.registry :refer [tools->openai-format tools->anthropic-format create-tool-dispatcher create-anthropic-tool-dispatcher]]
             [babashka.http-client :as client]
             [cheshire.core :as json]
             [clojure.string :as str]
@@ -25,9 +26,9 @@
   (get-model [this] "Get current model")
   (switch-model [this model] "Switch to given model"))
 
-;;;;;;;;;;;;;;;;;;;;;;
+;;=========================================
 ;; Utils
-;;;;;;;;;;;;;;;;;;;;;;
+;;=========================================
 
 ;; (defn compress [data]
 ;;   (let [baos (java.io.ByteArrayOutputStream.)]
@@ -73,7 +74,7 @@
                       :connect-timeout (or (:connect-timeout m) 10000)
                       :timeout (or (:timeout m) 25000)}))
     (catch Exception e 
-      {:error   true
+      {:isError   true
        :message (str (.getMessage e))})))
 
 (defn request-anthropic-messages
@@ -87,7 +88,7 @@
                   :connect-timeout (or (:connect-timeout m) 10000)
                   :timeout (or (:timeout m) 25000)})
     (catch Exception e
-      {:error   true
+      {:isError   true
        :message (str (.getMessage e))})))
 
 (def oops
@@ -120,9 +121,9 @@
    (str "Hey, it looks like " (rand-nth oops)
         ". Context tokens limit has been reached with " (:total-tokens last-response) " tokens.")))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;=========================================
 ;; Helper Fns for Streaming
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;=========================================
 
 (defn reduce-tool-call-stream
   "Reducer for streamed tool call given thus-accumulated and latest delta."
@@ -155,15 +156,15 @@
      (json/generate-string)
      (hash-map :body))))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;=========================================
 ;; OpenAIProvider Definition
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;=========================================
 
 (deftype OpenAIProvider [^:volatile-mutable model 
                          messages 
                          tools 
                          tool-time 
-                         metaphora]
+                         context]
   AIProviderOps
   (parse-response [this resp] (parse-response this resp nil))
   (parse-response [this resp clients]
@@ -198,8 +199,8 @@
                        tools (merge tools)
                        tool-choice (assoc :tool_choice {:type "function" :function {:name tool-choice}}))
                       (request-openai-completions))]
-        (if (:error response)
-          {:error true
+        (if (:isError response)
+          {:isError true
            :message (:message response)}
           response))))
   (add-tool-result [this tool-calls] (add-tool-result this tool-calls nil))
@@ -257,28 +258,28 @@
   (get-last-text [this] "TODO")
   (save-messages [this] (save-state! @messages (str "accent-openai-messages-" (System/currentTimeMillis) ".json")))
   (save-messages [this file] (save-state! @messages file))
-  (reset-messages [this] (reset! messages [{:role "system" :content (@metaphora :system)}]))
+  (reset-messages [this] (reset! messages [{:role "system" :content (@context :system)}]))
   
   AgentOps
   (get-model [this] model)
   (switch-model [this new-model] (set! model new-model)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;=====================================================
 ;; Anthropic Provider Def
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;=====================================================
 
 (deftype AnthropicProvider [^:volatile-mutable model 
                             messages 
                             tools 
                             tool-time 
-                            metaphora]
+                            context]
   
   AIProviderOps
   (parse-response [this resp] (parse-response this resp nil))
   (parse-response [this resp clients]
-    (if (:error resp)
+    (if (:isError resp)
       (do
-        (println "Error occurred:" (resp :message))
+        (mu/log ::error :data response)
         {:role    "system"
          :content (str "An error occurred: " (resp :message))})
       (let [resp       (json/parse-string (:body resp) true)
@@ -304,14 +305,14 @@
                          :messages    @messages
                          :temperature 0
                          :stream      false} 
-                        (@metaphora :system) (assoc :system (@metaphora :system))
+                        (@context :system) (assoc :system (@context :system))
                         tools (assoc :tools tools)
                         tool-choice (assoc :tool_choice {:type "tool" :name tool-choice}))
                        (request-anthropic-messages))]
-        (if (:error response)
+        (if (:isError response)
           (do 
             (mu/log ::error :data response)
-            {:error   true
+            {:isError   true
              :message (get response :message)}
           )
           response))))
@@ -337,60 +338,9 @@
   (switch-model [this new-model] (set! model new-model)))
 
 
-;;;;;;;;;;;;;;;;;;;;;
-;; Tools
-;;;;;;;;;;;;;;;;;;;;;
-
-(defn tool-time
-  "Stub function"
-  [tool-call]
-  (let [call-fn (get-in tool-call [:function :name])
-        args    (json/parse-string (get-in tool-call [:function :arguments]) true)] 
-       {:tool   call-fn
-        :result "Tools are not implemented in vanilla chat."
-        :error  false}))
-
-(defn anthropic-tool-time
-  "Stub function"
-  [tool-use]
-  (let [tool-call {:id       (:id tool-use)
-                   :type     "function"
-                   :function {:name      (:name tool-use)
-                              :arguments (json/generate-string (:input tool-use))}}]
-    (tool-time tool-call)))
-
-(defn convert-tools-for-anthropic
-  "Convert OpenAI tools schema to Anthropic tools schema"
-  [openai-tools & [cache-breakpoint?]]
-  (let [tools-count (count openai-tools)]
-    (mapv (fn [tool idx]
-        (cond->
-          {:name (get-in tool [:function :name])
-           :description (get-in tool [:function :description])
-           :input_schema (-> tool
-                             (get-in [:function :parameters]))}
-          (and cache-breakpoint? (= idx (dec tools-count))) (assoc :cache_control {"type" "ephemeral"})))
-        openai-tools (range tools-count))))
-
-(def search_tool_spec
-  "Example of a tool spec for a search tool; not used."
-  {:type "function"
-   :function
-   {:name "search"
-    :description "Search the web"
-    :parameters
-    {:type "object"
-     :properties
-     {:query
-      {:type "string"
-       :description "Search query"}}}
-    :required []}})
-
-(def tools [search_tool_spec])
-
-;;;;;;;;;;;;;;;;;;;;;
+;;==========================================
 ;; Models
-;;;;;;;;;;;;;;;;;;;;;
+;;==========================================
 
 (def openai-models
   "https://platform.openai.com/docs/models"
@@ -412,49 +362,45 @@
             "claude-3-sonnet-20240229" {:label "Claude 3 Sonnet"
                                         :context 200000}}})
 
-;;;;;;;;;;;;;;;;;;;;;
-;; Vanilla chat
-;;;;;;;;;;;;;;;;;;;;;
+;; =============================================================================
+;; Agent Configuration w/ Tools
+;; =============================================================================
 
-(defn ask [provider prompt]
+(defn create-agent
+  "Create an agent, possibly endowed with tools, using config and optional add'l context"
+  [agent-config & {:keys [context] :or {context (atom {})}}]
+  (let [provider (:provider agent-config)
+        model (:model agent-config)
+        role (:role agent-config)]
+    (case provider
+      :openai (OpenAIProvider. model
+                               (atom [{:role "system" :content role}])
+                               (tools->openai-format tool-set) 
+                               (create-tool-dispatcher tool-set)
+                               context)
+      :anthropic (AnthropicProvider. model
+                                     (atom [])
+                                     (tools->anthropic-format tool-set)
+                                     (create-anthropic-tool-dispatcher tool-set) 
+                                     (swap! context assoc :system role))
+      )))
+
+
+;; =============================================================================
+;; Basic Chat Access to Agent
+;; =============================================================================
+
+(defn ask [agent prompt]
   (->> prompt
-       (prompt-ai provider)
-       (parse-response provider)))
+       (prompt-ai agent)
+       (parse-response agent)))
 
-(def openai-init-prompt [{:role "system" :content "You are a helpful assistant."}])
-
-(def openai-messages (atom openai-init-prompt))
-
-(def anthropic-messages (atom [])) ;; system prompt is not in messages
-
-(def metaphora (atom {}))
-
-(def OpenAIVanillaChat 
-  (OpenAIProvider. "gpt-4o" 
-                   openai-messages
-                   nil 
-                   tool-time
-                   metaphora))
-
-(def AnthropicVanillaChat
-  (AnthropicProvider. "claude-3-7-sonnet-latest" 
-                      anthropic-messages 
-                      nil
-                      anthropic-tool-time
-                      metaphora))
-
-(defn chat [provider-agent]
-  (println "Chat initialized. Your message:") 
-  (loop [prompt (read-line)] 
-    (let [ai-reply (ask provider-agent prompt)] 
-      (println "assistant:" (ai-reply :content)) 
-      (when-not (:final ai-reply) 
-        (print "user: ") 
-        (flush) 
+(defn chat [agent]
+  (println "Chat initialized. Your message:")
+  (loop [prompt (read-line)]
+    (let [ai-reply (ask agent prompt)]
+      (println "assistant:" (ai-reply :content))
+      (when-not (:final ai-reply)
+        (print "user: ")
+        (flush)
         (recur (read-line))))))
-
-(defn -main [] 
-  (setup) 
-  (chat (if (= (@u :model-provider) "OpenAI") 
-    OpenAIVanillaChat 
-    AnthropicVanillaChat)))

--- a/src/accent/registry.clj
+++ b/src/accent/registry.clj
@@ -227,9 +227,10 @@
 ;; =============================================================================
 
 (defn execute-tool
-  "Execute a tool with given arguments"
+  "Execute a tool with given arguments.
+  NOTE: tool-name expected to be keyword, and converted if given as name."
   [tool-name args]
-  (if-let [tool (get-tool tool-name)]
+  (if-let [tool (get-tool (if (keyword? tool-name) tool-name (keyword tool-name)))]
     (try
       ((:handler tool) args)
       (catch Exception e

--- a/src/accent/registry.clj
+++ b/src/accent/registry.clj
@@ -28,7 +28,8 @@
   [:map {:description "JSON Schema for tool output"}])
 
 (def handler-schema
-  [:fn {:description "Function that handles tool execution"}])
+  [:fn {:description "Function that handles tool execution"}
+   ifn?])
 
 (def category-schema
   [:set {:description "Tool tags for organization"}
@@ -387,23 +388,34 @@
   "Macro to define and register a tool in one step.
    Handler can be either:
    - A function symbol/var: (deftool :my-tool \"...\" {...} my-existing-function)
-   - Function body forms: (deftool :my-tool \"...\" {...} (do-something args))"
-  [tool-name description parameters & {:keys [category permissions dependencies handler]
-                                       :or {category :general permissions #{} dependencies []}}
-   & handler-body]
-  (let [handler-fn (cond
+   - Function body forms: (deftool :my-tool \"...\" {...} (do-something args))
+   - Explicit :handler key: (deftool :my-tool \"...\" {...} :handler my-function)"
+  [tool-name description parameters & args]
+  (let [;; Parse keyword arguments and handler body
+        {opts true handler-body false} (group-by keyword? args)
+        opts-map (apply hash-map opts)
+        category (get opts-map :category #{})
+        permissions (get opts-map :permissions #{})
+        dependencies (get opts-map :dependencies [])
+        explicit-handler (get opts-map :handler)
+
+        handler-fn (cond
                      ;; If :handler key is provided, use it directly
-                     handler handler
-                     
+                     explicit-handler explicit-handler
+
                      ;; If handler-body is a single symbol, treat it as function reference
                      (and (= 1 (count handler-body))
                           (symbol? (first handler-body)))
                      (first handler-body)
-                     
+
                      ;; Otherwise, wrap the body in a function
+                     (seq handler-body)
+                     `(fn [~'args] ~@handler-body)
+
+                     ;; No handler provided
                      :else
-                     `(fn [~'args] ~@handler-body))]
-    `(register-tool! 
+                     (throw (IllegalArgumentException. "No handler provided for tool")))]
+    `(register-tool!
       {:tool-name ~tool-name
        :description ~description
        :parameters ~parameters
@@ -416,23 +428,35 @@
   "Macro to define and register a tool specifically for MCP SDK format.
    Handler can be either:
    - A function symbol/var: (defmcptool :my-tool \"...\" {...} my-existing-function)
-   - Function body forms: (defmcptool :my-tool \"...\" {...} (do-something args))"
-  [tool-name description input-schema & {:keys [category permissions dependencies output-schema handler]
-                                         :or {category :general permissions #{} dependencies []}}
-   & handler-body]
-  (let [handler-fn (cond
+   - Function body forms: (defmcptool :my-tool \"...\" {...} (do-something args))
+   - Explicit :handler key: (defmcptool :my-tool \"...\" {...} :handler my-function)"
+  [tool-name description input-schema & args]
+  (let [;; Parse keyword arguments and handler body
+        {opts true handler-body false} (group-by keyword? args)
+        opts-map (apply hash-map opts)
+        category (get opts-map :category :general)
+        permissions (get opts-map :permissions #{})
+        dependencies (get opts-map :dependencies [])
+        output-schema (get opts-map :output-schema)
+        explicit-handler (get opts-map :handler)
+
+        handler-fn (cond
                      ;; If :handler key is provided, use it directly
-                     handler handler
-                     
+                     explicit-handler explicit-handler
+
                      ;; If handler-body is a single symbol, treat it as function reference
                      (and (= 1 (count handler-body))
                           (symbol? (first handler-body)))
                      (first handler-body)
-                     
+
                      ;; Otherwise, wrap the body in a function
+                     (seq handler-body)
+                     `(fn [~'args] ~@handler-body)
+
+                     ;; No handler provided
                      :else
-                     `(fn [~'args] ~@handler-body))]
-    `(register-tool! 
+                     (throw (IllegalArgumentException. "No handler provided for tool")))]
+    `(register-tool!
       {:tool-name ~tool-name
        :description ~description
        :parameters ~input-schema
@@ -446,23 +470,35 @@
   "Macro to define and register a prompt in one step.
    Handler can be either:
    - A function symbol/var: (defprompt :my-prompt \"...\" my-existing-function)
-   - Function body forms: (defprompt :my-prompt \"...\" (generate-response args))"
-  [prompt-name description & {:keys [arguments category permissions dependencies handler]
-                              :or {arguments [] category :general permissions #{} dependencies []}}
-   & handler-body]
-  (let [handler-fn (cond
+   - Function body forms: (defprompt :my-prompt \"...\" (generate-response args))
+   - Explicit :handler key: (defprompt :my-prompt \"...\" :handler my-function)"
+  [prompt-name description & args]
+  (let [;; Parse keyword arguments and handler body
+        {opts true handler-body false} (group-by keyword? args)
+        opts-map (apply hash-map opts)
+        arguments (get opts-map :arguments [])
+        category (get opts-map :category :general)
+        permissions (get opts-map :permissions #{})
+        dependencies (get opts-map :dependencies [])
+        explicit-handler (get opts-map :handler)
+
+        handler-fn (cond
                      ;; If :handler key is provided, use it directly
-                     handler handler
-                     
+                     explicit-handler explicit-handler
+
                      ;; If handler-body is a single symbol, treat it as function reference
                      (and (= 1 (count handler-body))
                           (symbol? (first handler-body)))
                      (first handler-body)
-                     
+
                      ;; Otherwise, wrap the body in a function
+                     (seq handler-body)
+                     `(fn [~'args] ~@handler-body)
+
+                     ;; No handler provided
                      :else
-                     `(fn [~'args] ~@handler-body))]
-    `(register-prompt! 
+                     (throw (IllegalArgumentException. "No handler provided for prompt")))]
+    `(register-prompt!
       {:prompt-name ~prompt-name
        :description ~description
        :arguments ~arguments
@@ -578,7 +614,7 @@
     {:type "object"
      :properties {"name" {:type "string"}}
      :required ["name"]}
-    :category :social
+    :category #{:social}
     :permissions #{:read}
     
     {:message (str "Hello, " (:name args) "!")})
@@ -602,4 +638,5 @@
   
   ;; List everything
   (list-all-items)
+)
 

--- a/src/accent/registry.clj
+++ b/src/accent/registry.clj
@@ -1,0 +1,605 @@
+(ns accent.registry
+  (:require [cheshire.core :as json]
+            [malli.core :as m]
+            [malli.error :as me]))
+
+;; Registry atoms - maps names to definitions
+(defonce tool-registry (atom {}))
+(defonce prompt-registry (atom {}))
+(defonce metadata-registry (atom {}))
+
+;; =============================================================================
+;; Core Tool Definition Structure with Malli
+;; =============================================================================
+
+(def tool-name-schema
+  [:keyword {:description "Tool name as keyword"}])
+
+(def description-schema
+  [:string {:min 1 :description "Tool description"}])
+
+(def parameters-schema
+  [:map {:description "JSON Schema object for tool parameters"}
+   [:type [:= "object"]]
+   [:properties {:optional true} :map]
+   [:required {:optional true} [:vector :string]]])
+
+(def output-schema-schema
+  [:map {:description "JSON Schema for tool output"}])
+
+(def handler-schema
+  [:fn {:description "Function that handles tool execution"}])
+
+(def category-schema
+  [:set {:description "Tool tags for organization"}
+   :keyword])
+
+(def permissions-schema
+  [:set {:description "Required permissions"}
+   [:enum :read :write :admin]])
+
+(def dependencies-schema
+  [:vector {:description "Other tools this depends on"}
+   :keyword])
+
+(def tool-spec-schema
+  [:map {:description "Complete tool specification"}
+   [:tool-name tool-name-schema]
+   [:description description-schema]
+   [:parameters parameters-schema]
+   [:handler handler-schema]
+   [:category {:optional true} category-schema]
+   [:permissions {:optional true} permissions-schema]
+   [:dependencies {:optional true} dependencies-schema]
+   [:output-schema {:optional true} output-schema-schema]])
+
+;; =============================================================================
+;; Core Prompt Definition Structure with Malli
+;; =============================================================================
+
+(def prompt-name-schema
+  [:keyword {:description "Prompt name as keyword"}])
+
+(def prompt-argument-schema
+  [:map {:description "Prompt argument specification"}
+   [:name :string]
+   [:description {:optional true} :string]
+   [:required {:optional true} :boolean]])
+
+(def prompt-arguments-schema
+  [:vector {:description "List of prompt arguments"}
+   prompt-argument-schema])
+
+(def prompt-handler-schema
+  [:fn {:description "Function that handles prompt execution, returns messages"}])
+
+(def prompt-spec-schema
+  [:map {:description "Complete prompt specification"}
+   [:prompt-name prompt-name-schema]
+   [:description description-schema]
+   [:arguments {:optional true} prompt-arguments-schema]
+   [:handler prompt-handler-schema]
+   [:category {:optional true} category-schema]
+   [:permissions {:optional true} permissions-schema]
+   [:dependencies {:optional true} dependencies-schema]])
+
+;; =============================================================================
+;; Validation Functions
+;; =============================================================================
+
+(defn validate-tool-spec
+  "Validate a tool specification using Malli"
+  [tool-spec]
+  (if (m/validate tool-spec-schema tool-spec)
+    tool-spec
+    (let [errors (-> tool-spec-schema
+                     (m/explain tool-spec)
+                     (me/humanize))]
+      (throw (ex-info "Invalid tool specification" 
+                      {:tool-spec tool-spec
+                       :errors errors})))))
+
+(defn validate-prompt-spec
+  "Validate a prompt specification using Malli"
+  [prompt-spec]
+  (if (m/validate prompt-spec-schema prompt-spec)
+    prompt-spec
+    (let [errors (-> prompt-spec-schema
+                     (m/explain prompt-spec)
+                     (me/humanize))]
+      (throw (ex-info "Invalid prompt specification" 
+                      {:prompt-spec prompt-spec
+                       :errors errors})))))
+
+;; =============================================================================
+;; Registry Functions for Tools
+;; =============================================================================
+
+(defn register-tool!
+  "Register a tool in the registry"
+  [tool-spec]
+  (let [validated-spec (validate-tool-spec tool-spec)
+        tool-name (:tool-name validated-spec)]
+    (swap! tool-registry assoc tool-name validated-spec)
+    (swap! metadata-registry assoc tool-name 
+           (merge {:type :tool}
+                  (select-keys validated-spec [:category :permissions :dependencies])))
+    tool-name))
+
+(defn get-tool
+  "Get a tool definition by name"
+  [tool-name]
+  (get @tool-registry tool-name))
+
+(defn list-tools
+  "List all registered tools, optionally filtered by category"
+  ([]
+   (keys @tool-registry))
+  ([category]
+   (->> @tool-registry
+        (filter #(contains? (:category (val %)) category))
+        (map key))))
+
+(defn get-tools-by-category
+  "Get tools grouped by category"
+  []
+  (->> @tool-registry
+       (mapcat (fn [[k v]] 
+                 (map #(vector % k) (:category v))))
+       (group-by first)
+       (map (fn [[k v]] [k (map second v)]))
+       (into {})))
+
+;; =============================================================================
+;; Registry Functions for Prompts
+;; =============================================================================
+
+(defn register-prompt!
+  "Register a prompt in the registry"
+  [prompt-spec]
+  (let [validated-spec (validate-prompt-spec prompt-spec)
+        prompt-name (:prompt-name validated-spec)]
+    (swap! prompt-registry assoc prompt-name validated-spec)
+    (swap! metadata-registry assoc prompt-name 
+           (merge {:type :prompt}
+                  (select-keys validated-spec [:category :permissions :dependencies])))
+    prompt-name))
+
+(defn get-prompt
+  "Get a prompt definition by name"
+  [prompt-name]
+  (get @prompt-registry prompt-name))
+
+(defn list-prompts
+  "List all registered prompts, optionally filtered by category"
+  ([]
+   (keys @prompt-registry))
+  ([category]
+   (->> @prompt-registry
+        (filter #(= category (:category (val %))))
+        (map key))))
+
+(defn get-prompts-by-category
+  "Get prompts grouped by category"
+  []
+  (->> @prompt-registry
+       (group-by #(:category (val %)))
+       (into {})))
+
+;; =============================================================================
+;; Combined Registry Functions
+;; =============================================================================
+
+(defn list-all-items
+  "List all registered tools and prompts"
+  []
+  {:tools (keys @tool-registry)
+   :prompts (keys @prompt-registry)})
+
+(defn get-all-by-category
+  "Get all tools and prompts grouped by category"
+  []
+  (let [tools-by-cat (get-tools-by-category)
+        prompts-by-cat (get-prompts-by-category)]
+    (merge-with (fn [tools prompts]
+                  {:tools (or tools {})
+                   :prompts (or prompts {})})
+                (update-vals tools-by-cat #(hash-map :tools %))
+                (update-vals prompts-by-cat #(hash-map :prompts %)))))
+
+(defn search-items
+  "Search for tools and prompts by name or description"
+  [query]
+  (let [query-lower (clojure.string/lower-case query)
+        matches-query? (fn [item]
+                        (or (clojure.string/includes? 
+                             (clojure.string/lower-case (name (first item))) 
+                             query-lower)
+                            (clojure.string/includes? 
+                             (clojure.string/lower-case (:description (second item)))
+                             query-lower)))
+        matching-tools (filter matches-query? @tool-registry)
+        matching-prompts (filter matches-query? @prompt-registry)]
+    {:tools (into {} matching-tools)
+     :prompts (into {} matching-prompts)}))
+
+;; =============================================================================
+;; Execution Functions
+;; =============================================================================
+
+(defn execute-tool
+  "Execute a tool with given arguments"
+  [tool-name args]
+  (if-let [tool (get-tool tool-name)]
+    (try
+      ((:handler tool) args)
+      (catch Exception e
+        {:tool (name tool-name)
+         :result (.getMessage e)
+         :type "text"
+         :isError true}))
+    {:tool (name tool-name)
+     :result "Tool not found"
+     :type "text"
+     :isError true}))
+
+(defn execute-prompt
+  "Execute a prompt with given arguments"
+  [prompt-name args]
+  (if-let [prompt (get-prompt prompt-name)]
+    (try
+      ((:handler prompt) args)
+      (catch Exception e
+        {:prompt (name prompt-name)
+         :result (.getMessage e)
+         :type "text"
+         :isError true}))
+    {:prompt (name prompt-name)
+     :result "Prompt not found"
+     :type "text"
+     :isError true}))
+
+;; =============================================================================
+;; Selection Functions
+;; =============================================================================
+
+;; TODO
+
+;; =============================================================================
+;; Format Conversion for Chat Providers and MCP
+;; =============================================================================
+
+(defn tool->openai-spec
+  "Convert internal tool spec to OpenAI function calling format"
+  [tool-spec]
+  {:type "function"
+   :function {:name (name (:tool-name tool-spec))
+              :description (:description tool-spec)
+              :parameters (:parameters tool-spec)}})
+
+(defn tool->anthropic-spec
+  "Convert internal tool spec to Anthropic tools format"
+  [tool-spec]
+  {:name (name (:tool-name tool-spec))
+   :description (:description tool-spec)
+   :input_schema (:parameters tool-spec)})
+
+(defn tool->mcp-spec
+  "Convert internal tool spec to MCP SDK format"
+  [tool-spec]
+  (let [base {:name (name (:tool-name tool-spec))
+              :description (:description tool-spec)
+              :inputSchema (:parameters tool-spec)
+              :handler (:handler tool-spec)}]
+    (if-let [output-schema (:output-schema tool-spec)]
+      (assoc base :outputSchema output-schema)
+      base)))
+
+(defn prompt->mcp-spec
+  "Convert internal prompt spec to MCP SDK format"
+  [prompt-spec]
+  {:name (name (:prompt-name prompt-spec))
+   :description (:description prompt-spec)
+   :arguments (or (:arguments prompt-spec) [])
+   :handler (:handler prompt-spec)})
+
+(defn tools->openai-format
+  "Convert a set of tools to OpenAI format"
+  [tools]
+  (map tool->openai-spec (vals tools)))
+
+(defn tools->anthropic-format
+  "Convert a set of tools to Anthropic format"
+  [tools]
+  (map tool->anthropic-spec (vals tools)))
+
+(defn tools->mcp-format
+  "Convert a set of tools to MCP SDK format"
+  [tools]
+  (map tool->mcp-spec (vals tools)))
+
+(defn prompts->mcp-format
+  "Convert a set of prompts to MCP SDK format"
+  [prompts]
+  (map prompt->mcp-spec (vals prompts)))
+
+(defn tools->openai->anthropic
+  "Convert OpenAI tools format to Anthropic tools format"
+  [openai-tools & [cache-breakpoint?]]
+  (let [tools-count (count openai-tools)]
+    (mapv (fn [tool idx]
+            (cond->
+             {:name (get-in tool [:function :name])
+              :description (get-in tool [:function :description])
+              :input_schema (-> tool
+                                (get-in [:function :parameters]))}
+              (and cache-breakpoint? (= idx (dec tools-count))) (assoc :cache_control {"type" "ephemeral"})))
+          openai-tools (range tools-count))))
+
+;; =============================================================================
+;; Universal Dispatchers
+;; =============================================================================
+
+(defn create-tool-dispatcher
+  "Create a tool dispatcher function for a given tool set"
+  [tool-set]
+  (fn [tool-call]
+    (let [tool-name (keyword (get-in tool-call [:function :name]))
+          args (json/parse-string (get-in tool-call [:function :arguments]) true)]
+      (if (contains? tool-set tool-name)
+        (execute-tool tool-name args)
+        {:tool (name tool-name)
+         :result "Tool not available"
+         :type "text"
+         :isError true}))))
+
+(defn create-anthropic-tool-dispatcher
+  "Create an Anthropic-compatible tool dispatcher"
+  [tool-set]
+  (fn [tool-use]
+    (let [tool-name (keyword (:name tool-use))
+          args (:input tool-use)]
+      (if (contains? tool-set tool-name)
+        (execute-tool tool-name args)
+        {:tool (name tool-name)
+         :result "Tool not available"
+         :type "text"
+         :isError true}))))
+
+(defn create-prompt-dispatcher
+  "Create a prompt dispatcher function for a given prompt set"
+  [prompt-set]
+  (fn [prompt-call]
+    (let [prompt-name (keyword (:name prompt-call))
+          args (:arguments prompt-call)]
+      (if (contains? prompt-set prompt-name)
+        (execute-prompt prompt-name args)
+        {:prompt (name prompt-name)
+         :result "Prompt not available"
+         :type "text"
+         :error true}))))
+
+;; =============================================================================
+;; Helper Macros
+;; =============================================================================
+
+(defmacro deftool
+  "Macro to define and register a tool in one step.
+   Handler can be either:
+   - A function symbol/var: (deftool :my-tool \"...\" {...} my-existing-function)
+   - Function body forms: (deftool :my-tool \"...\" {...} (do-something args))"
+  [tool-name description parameters & {:keys [category permissions dependencies handler]
+                                       :or {category :general permissions #{} dependencies []}}
+   & handler-body]
+  (let [handler-fn (cond
+                     ;; If :handler key is provided, use it directly
+                     handler handler
+                     
+                     ;; If handler-body is a single symbol, treat it as function reference
+                     (and (= 1 (count handler-body))
+                          (symbol? (first handler-body)))
+                     (first handler-body)
+                     
+                     ;; Otherwise, wrap the body in a function
+                     :else
+                     `(fn [~'args] ~@handler-body))]
+    `(register-tool! 
+      {:tool-name ~tool-name
+       :description ~description
+       :parameters ~parameters
+       :category ~category
+       :permissions ~permissions
+       :dependencies ~dependencies
+       :handler ~handler-fn})))
+
+(defmacro defmcptool
+  "Macro to define and register a tool specifically for MCP SDK format.
+   Handler can be either:
+   - A function symbol/var: (defmcptool :my-tool \"...\" {...} my-existing-function)
+   - Function body forms: (defmcptool :my-tool \"...\" {...} (do-something args))"
+  [tool-name description input-schema & {:keys [category permissions dependencies output-schema handler]
+                                         :or {category :general permissions #{} dependencies []}}
+   & handler-body]
+  (let [handler-fn (cond
+                     ;; If :handler key is provided, use it directly
+                     handler handler
+                     
+                     ;; If handler-body is a single symbol, treat it as function reference
+                     (and (= 1 (count handler-body))
+                          (symbol? (first handler-body)))
+                     (first handler-body)
+                     
+                     ;; Otherwise, wrap the body in a function
+                     :else
+                     `(fn [~'args] ~@handler-body))]
+    `(register-tool! 
+      {:tool-name ~tool-name
+       :description ~description
+       :parameters ~input-schema
+       :output-schema ~output-schema
+       :category ~category
+       :permissions ~permissions
+       :dependencies ~dependencies
+       :handler ~handler-fn})))
+
+(defmacro defprompt
+  "Macro to define and register a prompt in one step.
+   Handler can be either:
+   - A function symbol/var: (defprompt :my-prompt \"...\" my-existing-function)
+   - Function body forms: (defprompt :my-prompt \"...\" (generate-response args))"
+  [prompt-name description & {:keys [arguments category permissions dependencies handler]
+                              :or {arguments [] category :general permissions #{} dependencies []}}
+   & handler-body]
+  (let [handler-fn (cond
+                     ;; If :handler key is provided, use it directly
+                     handler handler
+                     
+                     ;; If handler-body is a single symbol, treat it as function reference
+                     (and (= 1 (count handler-body))
+                          (symbol? (first handler-body)))
+                     (first handler-body)
+                     
+                     ;; Otherwise, wrap the body in a function
+                     :else
+                     `(fn [~'args] ~@handler-body))]
+    `(register-prompt! 
+      {:prompt-name ~prompt-name
+       :description ~description
+       :arguments ~arguments
+       :category ~category
+       :permissions ~permissions
+       :dependencies ~dependencies
+       :handler ~handler-fn})))
+
+;; =============================================================================
+;; Enhanced Validation and Introspection
+;; =============================================================================
+
+(defn validate-dependencies
+  "Check if all dependencies are satisfied across tools and prompts"
+  [tool-set prompt-set]
+  (let [available-items (set (concat (keys tool-set) (keys prompt-set)))
+        check-deps (fn [items]
+                     (->> items
+                          (map (fn [[name spec]]
+                                 (let [deps (:dependencies spec [])]
+                                   [name (filter #(not (contains? available-items %)) deps)])))
+                          (filter #(seq (second %)))
+                          (into {})))]
+    {:missing-tool-dependencies (check-deps tool-set)
+     :missing-prompt-dependencies (check-deps prompt-set)}))
+
+(defn health-check-registry
+  "Perform basic health checks on the entire registry"
+  []
+  (let [tools @tool-registry
+        prompts @prompt-registry
+        all-categories (set (concat (map #(:category (val %)) tools)
+                                   (map #(:category (val %)) prompts)))]
+    {:total-tools (count tools)
+     :total-prompts (count prompts)
+     :categories (vec all-categories)
+     :tools-by-category (get-tools-by-category)
+     :prompts-by-category (get-prompts-by-category)
+     :dependency-issues (validate-dependencies tools prompts)
+     :validation-errors {:tools (keep (fn [[name spec]]
+                                       (when-not (m/validate tool-spec-schema spec)
+                                         [name (me/humanize (m/explain tool-spec-schema spec))]))
+                                     tools)
+                         :prompts (keep (fn [[name spec]]
+                                         (when-not (m/validate prompt-spec-schema spec)
+                                           [name (me/humanize (m/explain prompt-spec-schema spec))]))
+                                       prompts)}}))
+
+;; =============================================================================
+;; Schema Utilities
+;; =============================================================================
+
+(defn describe-schemas
+  "Get human-readable descriptions of all schemas"
+  []
+  {:tool-spec (m/form tool-spec-schema)
+   :prompt-spec (m/form prompt-spec-schema)})
+
+;; =============================================================================
+;; Migration Utilities with Validation
+;; =============================================================================
+
+(defn import-mcp-tool-with-validation
+  "Import an existing MCP tool definition with Malli validation"
+  [mcp-tool-def & {:keys [category permissions dependencies]
+                   :or {category :general permissions #{} dependencies []}}]
+  (let [tool-spec {:tool-name (keyword (:name mcp-tool-def))
+                   :description (:description mcp-tool-def)
+                   :parameters (:inputSchema mcp-tool-def)
+                   :category category
+                   :permissions permissions  
+                   :dependencies dependencies
+                   :handler (:handler mcp-tool-def)}]
+    ;; This will validate using Malli schemas
+    (register-tool! tool-spec)))
+
+;; =============================================================================
+;; Development Helpers
+;; =============================================================================
+
+(defn reset-registry!
+  "Clear all tools and prompts from the registry (useful for development)"
+  []
+  (reset! tool-registry {})
+  (reset! prompt-registry {})
+  (reset! metadata-registry {}))
+
+(defn item-exists?
+  "Check if a tool or prompt exists in the registry"
+  [item-name]
+  (or (contains? @tool-registry item-name)
+      (contains? @prompt-registry item-name)))
+
+(defn get-item-info
+  "Get detailed information about a tool or prompt"
+  [item-name]
+  (let [metadata (get @metadata-registry item-name)]
+    (case (:type metadata)
+      :tool (-> (get-tool item-name)
+                (dissoc :handler)
+                (assoc :handler-type (type (:handler (get-tool item-name)))))
+      :prompt (-> (get-prompt item-name)
+                  (dissoc :handler)
+                  (assoc :handler-type (type (:handler (get-prompt item-name)))))
+      nil)))
+
+(comment
+  ;; Example usage
+  
+  ;; Define tools and prompts
+  (deftool :greet
+    "Greet a person"
+    {:type "object"
+     :properties {"name" {:type "string"}}
+     :required ["name"]}
+    :category :social
+    :permissions #{:read}
+    
+    {:message (str "Hello, " (:name args) "!")})
+  
+  (defprompt :analyze-code
+    "Analyze code for improvements"
+    :arguments [{:name "language" :description "Programming language" :required true}
+                {:name "code" :description "Code to analyze" :required true}]
+    :category :development
+    :permissions #{:read}
+    
+    {:messages [{:role "assistant"
+                 :content {:type "text"
+                          :text (str "Analyzing " (:language args) " code: " (:code args))}}]})
+  
+  ;; Check registry health
+  (health-check-registry)
+  
+  ;; Search for items
+  (search-items "code")
+  
+  ;; List everything
+  (list-all-items)
+

--- a/src/accent/registry.clj
+++ b/src/accent/registry.clj
@@ -305,17 +305,17 @@
    :handler (:handler prompt-spec)})
 
 (defn tools->openai-format
-  "Convert a set of tools to OpenAI format"
+  "Convert a set of tools in internal registry format to OpenAI format"
   [tools]
   (map tool->openai-spec (vals tools)))
 
 (defn tools->anthropic-format
-  "Convert a set of tools to Anthropic format"
+  "Convert a set of tools in internal registry format to Anthropic format"
   [tools]
   (map tool->anthropic-spec (vals tools)))
 
 (defn tools->mcp-format
-  "Convert a set of tools to MCP SDK format"
+  "Convert set of tools in internal registry format to MCP SDK format"
   [tools]
   (map tool->mcp-spec (vals tools)))
 
@@ -324,8 +324,8 @@
   [prompts]
   (map prompt->mcp-spec (vals prompts)))
 
-(defn tools->openai->anthropic
-  "Convert OpenAI tools format to Anthropic tools format"
+(defn tools->openai->anthropic-format
+  "Convert OpenAI tools format directly to Anthropic tools format"
   [openai-tools & [cache-breakpoint?]]
   (let [tools-count (count openai-tools)]
     (mapv (fn [tool idx]
@@ -336,6 +336,14 @@
                                 (get-in [:function :parameters]))}
               (and cache-breakpoint? (= idx (dec tools-count))) (assoc :cache_control {"type" "ephemeral"})))
           openai-tools (range tools-count))))
+
+(defn select-tools
+  "Select tools from registry by key, in the desired format"
+  [tool-keys provider]
+  (let [tools (select-keys @tool-registry tool-keys)]
+       (case provider
+         :anthropic (tools->anthropic-format tools)
+         :openai (tools->openai-format tools))))
 
 ;; =============================================================================
 ;; Universal Dispatchers

--- a/src/accent/registry.clj
+++ b/src/accent/registry.clj
@@ -32,16 +32,14 @@
    ifn?])
 
 (def category-schema
-  [:set {:description "Tool tags for organization"}
-   :keyword])
+  [:set {:description "Tool tags for organization"} :keyword])
 
 (def permissions-schema
   [:set {:description "Required permissions"}
    [:enum :read :write :admin]])
 
 (def dependencies-schema
-  [:vector {:description "Other tools this depends on"}
-   :keyword])
+  [:vector {:description "Other tools this depends on"} :keyword])
 
 (def tool-spec-schema
   [:map {:description "Complete tool specification"}
@@ -394,81 +392,18 @@
 
 (defmacro deftool
   "Macro to define and register a tool in one step.
-   Handler can be either:
-   - A function symbol/var: (deftool :my-tool \"...\" {...} my-existing-function)
-   - Function body forms: (deftool :my-tool \"...\" {...} (do-something args))
-   - Explicit :handler key: (deftool :my-tool \"...\" {...} :handler my-function)"
-  [tool-name description parameters & args]
-  (let [;; Parse keyword arguments and handler body
-        {opts true handler-body false} (group-by keyword? args)
-        opts-map (apply hash-map opts)
-        category (get opts-map :category #{})
-        permissions (get opts-map :permissions #{})
-        dependencies (get opts-map :dependencies [])
-        explicit-handler (get opts-map :handler)
-
-        handler-fn (cond
-                     ;; If :handler key is provided, use it directly
-                     explicit-handler explicit-handler
-
-                     ;; If handler-body is a single symbol, treat it as function reference
-                     (and (= 1 (count handler-body))
-                          (symbol? (first handler-body)))
-                     (first handler-body)
-
-                     ;; Otherwise, wrap the body in a function
-                     (seq handler-body)
-                     `(fn [~'args] ~@handler-body)
-
-                     ;; No handler provided
-                     :else
-                     (throw (IllegalArgumentException. "No handler provided for tool")))]
+   TODO: Handler can be either
+   - Function body forms: (deftool :my-tool \"...\" {...} :handler (fn [args] (something-with-args)))
+   - Function symbol: (deftool :my-tool \"...\" {...} :handler my-function-symbol)"
+  [tool-name description parameters & {:keys [category permissions handler] :as opts}]
+  (let [category (get opts :category #{})
+        permissions (get opts :permissions #{})
+        dependencies (get opts :dependencies [])
+        handler-fn (get opts :handler)]
     `(register-tool!
       {:tool-name ~tool-name
        :description ~description
        :parameters ~parameters
-       :category ~category
-       :permissions ~permissions
-       :dependencies ~dependencies
-       :handler ~handler-fn})))
-
-(defmacro defmcptool
-  "Macro to define and register a tool specifically for MCP SDK format.
-   Handler can be either:
-   - A function symbol/var: (defmcptool :my-tool \"...\" {...} my-existing-function)
-   - Function body forms: (defmcptool :my-tool \"...\" {...} (do-something args))
-   - Explicit :handler key: (defmcptool :my-tool \"...\" {...} :handler my-function)"
-  [tool-name description input-schema & args]
-  (let [;; Parse keyword arguments and handler body
-        {opts true handler-body false} (group-by keyword? args)
-        opts-map (apply hash-map opts)
-        category (get opts-map :category :general)
-        permissions (get opts-map :permissions #{})
-        dependencies (get opts-map :dependencies [])
-        output-schema (get opts-map :output-schema)
-        explicit-handler (get opts-map :handler)
-
-        handler-fn (cond
-                     ;; If :handler key is provided, use it directly
-                     explicit-handler explicit-handler
-
-                     ;; If handler-body is a single symbol, treat it as function reference
-                     (and (= 1 (count handler-body))
-                          (symbol? (first handler-body)))
-                     (first handler-body)
-
-                     ;; Otherwise, wrap the body in a function
-                     (seq handler-body)
-                     `(fn [~'args] ~@handler-body)
-
-                     ;; No handler provided
-                     :else
-                     (throw (IllegalArgumentException. "No handler provided for tool")))]
-    `(register-tool!
-      {:tool-name ~tool-name
-       :description ~description
-       :parameters ~input-schema
-       :output-schema ~output-schema
        :category ~category
        :permissions ~permissions
        :dependencies ~dependencies

--- a/src/accent/tools.clj
+++ b/src/accent/tools.clj
@@ -1,0 +1,210 @@
+(ns accent.tools
+  (:require [accent.registry :as registry]
+            [curate.synapse :refer [syn curate-dataset create-folder get-table-sample get-entity-wiki get-entity-schema get-user-name query-table set-annotations]]
+            [curate.util :as cu]
+            [database.arachne :as arachne]
+            [cheshire.core :as json]
+            [malli.core :as m]))
+
+;; =============================================================================
+;; Define and Register Synapse Tools
+;; =============================================================================
+
+(defn get-table-context-handler
+  "Combine retrieval of table schema and Wiki doc as table context"
+  [{:keys [table_id]}]
+  (let [schema (get-table-sample @syn table_id)
+        doc (get-entity-wiki @syn table_id)
+        text (str {:schema schema :doc doc})] 
+    {:result text
+     :type "text"
+     :isError false}))
+
+(registry/deftool :get-table-context
+  "Use this to confirm the availability of a Synapse table, retrieve its queryable fields (schema), and get any docs that exists for the table. 
+   In some cases, the user may not have table access or the available fields may be insufficient for the user question. 
+   The returned context can help answer a general question about the table, construct a valid query, or explain why the user question may not be feasible."
+  {:type "object"
+   :properties
+   {"table_id"
+    {:type "string"
+     :description "Id of the table to use, which should be specified by the user."}}
+   :required ["table_id"]}
+  :category #{:data-access :synapse}
+  :permissions #{:read}
+
+  get-table-context-handler)
+
+;; ----------------------------------------------------------------------------
+
+(defn query-table-handler
+  [{:keys [table_id query]}] 
+  {:result (str (query-table @syn table_id query))
+   :type "text"
+   :isError false})
+
+(registry/deftool :query-table
+  "Use to query table with SQL to help answer a user question; query should include only queryable fields; only a subset of valid SQL is allowed -- do not include update clauses."
+  {:type "object"
+   :properties
+   {"table_id"
+    {:type "string"
+     :description "Table id, e.g. 'syn5464523'"}
+    "query"
+    {:type "string"
+     :description "A valid SQL query."}}
+   :required ["table_id" "query"]}
+  :category #{:data-access :synapse}
+  :permissions #{:read} 
+
+  query-table-handler)
+
+;; ----------------------------------------------------------------------------
+
+(defn get-wiki-handler
+  [{:keys [id]}]
+  {:result (get-entity-wiki @syn id)
+   :type   "text"
+   :isError false})
+
+(registry/deftool :get-wiki
+  "Get the Wiki page, if it exists, for a Synapse entity."
+  {:type "object"
+   :properties
+   {"id"
+    {:type "string"
+     :description "Synapse entity id, e.g. 'syn12345678'"}}
+   :required ["id"]}
+  :category #{:documentation :synapse}
+  :permissions #{:read}
+
+  get-entity-wiki-handler)
+
+;; ----------------------------------------------------------------------------
+
+(defn commit-handler
+  "Store the data as annotations on an existing entity"
+  [{:keys [data entity_id collection_id product_name]}]
+  (let [ann-map (json/parse-string data)
+        id (if entity_id entity_id (create-folder @syn product_name entity_id))
+        response (set-annotations @syn id ann-map)]
+    (println "Metadata stored on/within" collection_id entity_id)
+    (if (= 200 (:status response))
+      {:result "Committed successfully."
+       :type "text"
+       :isError false}
+      {:result (str "Failed to store, server returned status " (:status response))
+       :type "text"
+       :isError true})))
+
+(registry/deftool :commit
+  "Add new or updated metadata for an entity (data product) into the Synapse platform."
+  {:type "object"
+   :properties
+   {"data"
+    {:type "string"
+     :description "JSON string representing the entity."}
+    "entity_id"
+    {:type "string"
+     :description "Id of existing entity to update, or omit to add metadata for a new entity. If omitted, use `collection_id` and `product_name`."}
+    "collection_id"
+    {:type "string"
+     :description "(Only for new entities where `entity_id` does not exist) Provide the id of a Synapse collection where changes can be created."}
+    "product_name"
+    {:type "string"
+     :description "(Only for new entities where `entity_id` does not exist) Suggested name or title for the entity"}}
+   :required ["data"]}
+  :category #{:data-management :synapse}
+  :permissions #{:write}
+
+  commit-handler)
+
+;; ----------------------------------------------------------------------------
+
+(defn get-user-name-handler
+  [{:keys [userid]}]
+  {:result (str (get-user-name @syn (str userid)))
+   :type   "text"
+   :isError false})
+
+(registry/deftool :get-user-name
+  "Get a user name given a user id (results depend on how the user filled out this field, and in some cases may contain first name only or may be blank)."
+  {:type "object"
+   :properties
+   {"userid"
+    {:type "number"
+     :description "Ids are integers, e.g. 273960."}}}
+  :category #{:user-management :synapse}
+  :permissions #{:read}
+
+  get-user-name-handler)
+
+;; =============================================================================
+;; Define and Register Arachne Tools
+;; =============================================================================
+
+(registry/deftool 
+  :find-matching-attribute
+  "Given a source attribute, find a matching attribute in a target attribute set."
+  {:type "object"
+   :properties {"attribute_uri" {:type "string"
+                                :description "The source attribute URI"}}
+   :required ["attribute_uri"]}
+  :category #{:data-mapping}
+  :permissions #{:read}
+  
+  (let [result (arachne/get-same-property (:attribute_uri args))]
+    (if (or (nil? result) (empty? result))
+      {:result "No known matches were found." :type "text"}
+      {:result (str result) :type "text"})))
+
+;; ----------------------------------------------------------------------------
+
+(registry/deftool
+  :get-template-meta
+  "Get information about an entity template such as its attributes and order."
+  {:type "object"
+   :properties {"template_uri" {:type "string"
+                               :description "The template URI"}}
+   :required ["template_uri"]}
+  :category #{:data-mapping}
+  :permissions #{:read}
+  
+  (let [result (arachne/describe-template-columns (:template_uri args))]
+    (if (or (nil? result) (empty? result))
+      {:result "No result." :type "text"}
+      {:result (str result) :type "text"})))
+
+;; ----------------------------------------------------------------------------
+
+(registry/deftool
+  :read-file
+  "Read text content from local file or URL."
+  {:type "object"
+   :properties {"file" {:type "string"
+                       :description "Local file path or URL"}}
+   :required ["file"]}
+  :category #{:file-io}
+  :permissions #{:read}
+  
+  (let [file-obj (java.io.File. (:file args))
+        size-in-kb (/ (.length file-obj) 1024.0)]
+    (if (< size-in-kb 10)
+      {:result (slurp (:file args)) :type "text"}
+      {:result "File is too large." :type "text"})))
+
+;; ----------------------------------------------------------------------------
+
+(registry/deftool
+  :submit-data
+  "Submit data content."
+  {:type "object"
+   :properties {"data" {:type "string" :description "Data to write"}
+               "filename" {:type "string" :description "Output filename"}}
+   :required ["data" "filename"]}
+  :category #{:file-io}
+  :permissions #{:write}
+  
+  ;; (spit (:filename args) (:data args))
+  {:result "File stored." :type "text"})
+

--- a/src/accent/tools.clj
+++ b/src/accent/tools.clj
@@ -138,31 +138,120 @@
 ;; Define and Register Arachne Tools
 ;; =============================================================================
 
+(defn find-matching-attribute-handler
+  [{:keys [attribute_uri]}]
+  (let [result (arachne/get-same-property attribute_uri)]
+    ;; (mu/log ::find-matching-attribute :param attribute_uri)
+    (if (or (nil? result) (empty? result))
+      {:result "No known matches were found."
+       :type "text"}
+      {:result (str result)
+       :type "text"})))
+
 (registry/deftool 
   :find-matching-attribute
   "Given a source attribute, find a matching attribute in a target attribute set."
   {:type "object"
-   :properties {"attribute_uri" {:type "string"
-                                :description "The source attribute URI"}}
+   :properties 
+   {"attribute_uri" 
+    {:type "string" 
+     :description "The source attribute URI"}}
    :required ["attribute_uri"]}
   :category #{:data-mapping}
   :permissions #{:read}
-  :handler identity)
+  :handler find-matching-attribute-handler)
 
 ;; ----------------------------------------------------------------------------
+
+(defn get-attribute-meta-handler
+  [{:keys [attribute_uri]}]
+  (let [result (arachne/describe-uri attribute_uri)]
+    ;; (mu/log ::get-attribute-meta  :param attribute_uri)
+    (if (or (nil? result) (empty? result))
+      {:result "No result."
+       :type "text"}
+      {:result (str result)
+       :type "text"})))
+
+(registry/deftool
+  :get-attribute-meta
+  "Get attribute info using its URI."
+  {:type "object"
+   :properties 
+   {"attribute_uri" 
+    {:type "string" 
+     :description "The attribute URI, generally of the format '<http://syn.org/{data_standard}/{template}>', e.g. '<http://syn.org/gdc/sample>'."}}
+   :required ["attribute_uri"]}
+  :category #{:data-mapping}
+  :permissions #{:read}
+  :handler get-attribute-meta-handler)
+
+;; ----------------------------------------------------------------------------
+
+(defn get-template-meta-handler
+  [{:keys [template_uri]}]
+  (let [result (arachne/describe-template-columns template_uri)]
+    (if (or (nil? result) (empty? result))
+      {:result "No result."
+       :type "text"}
+      {:result (str result)
+       :type "text"})))
 
 (registry/deftool
   :get-template-meta
   "Get information about an entity template such as its attributes and order."
   {:type "object"
-   :properties {"template_uri" {:type "string"
-                               :description "The template URI"}}
+   :properties 
+   {"template_uri" 
+    {:type "string" 
+     :description "The template URI"}}
    :required ["template_uri"]}
   :category #{:data-mapping}
   :permissions #{:read}
-  :handler identity)
+  :handler get-template-meta-handler)
 
 ;; ----------------------------------------------------------------------------
+
+(defn list-standard-templates-handler
+  [{:keys [standard_uri]}]
+  (let [result (arachne/list-templates standard_uri)]
+    ;; (mu/log ::list-standard-templates  :param standard_uri)
+    (if (or (nil? result) (empty? result))
+      {:result "No result."
+       :type "text"}
+      {:result (str result)
+       :type "text"})))
+
+(registry/deftool
+  :list-standard-templates
+  "List the templates defined by a data standard. Returns template URIs, which can be used with 'get_template_meta' to get more info about a specific template."
+  {:type "object" 
+   :properties 
+   {"standard_uri" 
+    {:type "string" 
+     :enum ["<http://syn.org/gdc>"] 
+     :description "The data standard URI, of the format '<http://syn.org/{data_standard}>', i.e. '<http://syn.org/gdc>'. Currently, only GDC standard is supported."}}
+   :required ["standard_uri"]}
+  :category #{:data-mapping}
+  :permissions #{:read}
+  :handler list-standard-templates-handler)
+
+;; =============================================================================
+;; Define and Register I/O Tools
+;; =============================================================================
+
+(defn read-file-handler
+  [{:keys [file]}]
+  (let [file-obj (java.io.File. file)
+        size-in-kb (/ (.length file-obj) 1024.0)]
+    ;; (mu/log ::read-file  :filename file)
+    (if (< size-in-kb 10)
+      {:result (slurp file)
+       :type "text"
+       :isError false}
+      {:result "File is too large."
+       :type "text"
+       :isError true})))
 
 (registry/deftool
   :read-file
@@ -171,11 +260,19 @@
    :properties {"file" {:type "string"
                        :description "Local file path or URL"}}
    :required ["file"]}
-  :category #{:file-io}
+  :category #{:io}
   :permissions #{:read}
-  :handler identity)
+  :handler read-file-handler)
 
 ;; ----------------------------------------------------------------------------
+
+(defn submit-data-handler
+  "Defaults to storing data to a file."
+  [{:keys [data filename]}]
+  (let [file (spit filename data)]
+    ;; (mu/log ::submit-data :filename filename :message data)
+    {:result "Data stored."
+     :type "text"}))
 
 (registry/deftool
   :submit-data
@@ -184,6 +281,6 @@
    :properties {"data" {:type "string" :description "Data to write"}
                "filename" {:type "string" :description "Output filename"}}
    :required ["data" "filename"]}
-  :category #{:file-io}
+  :category #{:io}
   :permissions #{:write}
-  :handler identity)
+  :handler submit-data-handler)

--- a/src/accent/tools.clj
+++ b/src/accent/tools.clj
@@ -150,12 +150,12 @@
 
 (registry/deftool 
   :find-matching-attribute
-  "Given a source attribute, find a matching attribute in a target attribute set."
+  "Given a source attribute, find the matching/synonymous attribute(s) in a target attribute set."
   {:type "object"
    :properties 
    {"attribute_uri" 
     {:type "string" 
-     :description "The source attribute URI"}}
+     :description "The source attribute URI, generally of the format '<http://syn.org/{data_standard}/{template}/{attribute}>'."}}
    :required ["attribute_uri"]}
   :category #{:data-mapping}
   :permissions #{:read}
@@ -237,7 +237,7 @@
   :handler list-standard-templates-handler)
 
 ;; =============================================================================
-;; Define and Register I/O Tools
+;; Define and Register File Tools
 ;; =============================================================================
 
 (defn read-file-handler
@@ -263,6 +263,28 @@
   :category #{:io}
   :permissions #{:read}
   :handler read-file-handler)
+
+;; ----------------------------------------------------------------------------
+
+(defn summarize-file-handler
+  [{:keys [file]}]
+  (let [result (cu/summarize-manifest file)]
+    ;; (mu/log ::summarize-file  :filename file)
+    {:result (str result)
+     :type :success}))
+
+(registry/deftool
+  :summarize-file
+  "Get summary of data within a csv file, such as columns present, unique values and value ranges. This can handle larger files."
+  {:type "object"
+   :properties
+   {"file"
+    {:type "string"
+     :description "Local file path or URL"}}
+   :required ["file"]}
+  :category #{:io}
+  :permissions #{:read}
+  :handler summarize-file-handler)
 
 ;; ----------------------------------------------------------------------------
 

--- a/src/accent/tools.clj
+++ b/src/accent/tools.clj
@@ -32,8 +32,7 @@
    :required ["table_id"]}
   :category #{:data-access :synapse}
   :permissions #{:read}
-
-  get-table-context-handler)
+  :handler get-table-context-handler)
 
 ;; ----------------------------------------------------------------------------
 
@@ -55,9 +54,8 @@
      :description "A valid SQL query."}}
    :required ["table_id" "query"]}
   :category #{:data-access :synapse}
-  :permissions #{:read} 
-
-  query-table-handler)
+  :permissions #{:read}
+  :handler query-table-handler)
 
 ;; ----------------------------------------------------------------------------
 
@@ -77,8 +75,7 @@
    :required ["id"]}
   :category #{:documentation :synapse}
   :permissions #{:read}
-
-  get-entity-wiki-handler)
+  :handler get-wiki-handler)
 
 ;; ----------------------------------------------------------------------------
 
@@ -116,8 +113,7 @@
    :required ["data"]}
   :category #{:data-management :synapse}
   :permissions #{:write}
-
-  commit-handler)
+  :handler commit-handler)
 
 ;; ----------------------------------------------------------------------------
 
@@ -136,8 +132,7 @@
      :description "Ids are integers, e.g. 273960."}}}
   :category #{:user-management :synapse}
   :permissions #{:read}
-
-  get-user-name-handler)
+  :handler get-user-name-handler)
 
 ;; =============================================================================
 ;; Define and Register Arachne Tools
@@ -152,11 +147,7 @@
    :required ["attribute_uri"]}
   :category #{:data-mapping}
   :permissions #{:read}
-  
-  (let [result (arachne/get-same-property (:attribute_uri args))]
-    (if (or (nil? result) (empty? result))
-      {:result "No known matches were found." :type "text"}
-      {:result (str result) :type "text"})))
+  :handler identity)
 
 ;; ----------------------------------------------------------------------------
 
@@ -169,11 +160,7 @@
    :required ["template_uri"]}
   :category #{:data-mapping}
   :permissions #{:read}
-  
-  (let [result (arachne/describe-template-columns (:template_uri args))]
-    (if (or (nil? result) (empty? result))
-      {:result "No result." :type "text"}
-      {:result (str result) :type "text"})))
+  :handler identity)
 
 ;; ----------------------------------------------------------------------------
 
@@ -186,12 +173,7 @@
    :required ["file"]}
   :category #{:file-io}
   :permissions #{:read}
-  
-  (let [file-obj (java.io.File. (:file args))
-        size-in-kb (/ (.length file-obj) 1024.0)]
-    (if (< size-in-kb 10)
-      {:result (slurp (:file args)) :type "text"}
-      {:result "File is too large." :type "text"})))
+  :handler identity)
 
 ;; ----------------------------------------------------------------------------
 
@@ -204,7 +186,4 @@
    :required ["data" "filename"]}
   :category #{:file-io}
   :permissions #{:write}
-  
-  ;; (spit (:filename args) (:data args))
-  {:result "File stored." :type "text"})
-
+  :handler identity)

--- a/src/agents/arachne.clj
+++ b/src/agents/arachne.clj
@@ -8,10 +8,6 @@
             [clojure.string :as str]
             [com.brunobonacci.mulog :as mu]))
 
-;;;;;;;;;;;;;;;;;;;;;
-;; INTERNAL
-;;;;;;;;;;;;;;;;;;;;;
-
 (mu/start-publisher! {:type :simple-file
                       :filename "/tmp/mulog/events.edn"})
 

--- a/src/agents/arachne.clj
+++ b/src/agents/arachne.clj
@@ -2,6 +2,7 @@
   (:gen-class)
   (:require [accent.state :refer [setup u]]
             [accent.chat :as agent]
+            [accent.tools :as tools]
             [curate.util :as cu]
             [database.arachne :as arachne]
             [cheshire.core :as json]

--- a/src/agents/arachne.clj
+++ b/src/agents/arachne.clj
@@ -1,291 +1,45 @@
 (ns agents.arachne
   (:gen-class)
   (:require [accent.state :refer [setup u]]
-            [accent.chat :as chat]
+            [accent.chat :as agent]
             [curate.util :as cu]
             [database.arachne :as arachne]
             [cheshire.core :as json]
             [clojure.string :as str]
             [com.brunobonacci.mulog :as mu]))
 
+(setup) 
+
 (mu/start-publisher! {:type :simple-file
                       :filename "/tmp/mulog/events.edn"})
 
-;;;;;;;;;;;;;;;;;;;;;
-;; Tool defs
-;;;;;;;;;;;;;;;;;;;;;
+(def arachne-agent-config
+  {:name "Arachne Biomedical Data Fabric Agent"
+   :provider :anthropic ;; (@u :model-provider)
+   :model "claude-3-5-sonnet-20241022"
+   :role (str
+          "You are a data management agent who specializes in reviewing diverse data templates based on the CCDI standard and translating them to a desired common standard called **GDC**. "
+          "Your most common workflow consists of obtaining from the user the paths to one or more CSV templates of entity data that they need to transform to a target set of templates in the GDC standard. "
+          "For each CSV file with records of some entity type, you can use the 'read_file' tool to extract and see the entity data records. "
+          ;; "Then you can use the tool load_into_working_graph to put the entity data into an OLAP knowledge graph, which is similar to using a data warehouse for data transformations. " 
+          "Given the input, you can query for information about matching target attributes and target templates to better understand specifications for the transformation. "
+          "For example, given a CSV file called 'sample.csv' that may contain column 'sample_attribute_1', you can see whether 'sample_attribute_1' matches an attribute in the GDC standard, which GDC template it's used in, and acceptable values for the GDC version of the attribute. "
+          "You may retrieve the list of potential target templates in the GDC standard. Note that the inputs may not have a 1:1 match to the GDC templates, so not all GDC templates are output targets, only the relevant ones. "
+          "Once you have determined which GDC templates to output and how to translate the data sufficiently, either submit the csv data directly or use the mapping/transform specification schema (below), whichever is better. The output must contain/specify all columns in the target template!\n"
+          (slurp "resources/map_spec.json"))
+   :tools #{:find-matching-attribute :get-attribute-meta :get-template-meta :list-standard-templates :summarize-file}})
 
-(def find_matching_attribute_spec
-  {:type "function"
-   :function
-   {:name "find_matching_attribute"
-    :description (str "Given a source attribute, find a matching attribute in a target attribute set. "
-                      "This will return the matching attribute if it exists."
-                      )
-    :parameters
-    {:type "object"
-     :properties
-     {:attribute_uri
-      {:type "string"
-       :description "The source attribute URI, should be in the format '<http://syn.org/{data_standard}/{template}/{attribute}>', e.g. '<http://syn.org/ccdi/sample/sample_id>'."}
-     }
-    }
-    :required ["attribute_uri"] }})
-
-(def get_attribute_meta_spec
-  {:type "function"
-   :function
-   {:name "get_attribute_meta"
-    :description (str "Get all information for an attribute using its URI.")
-    :parameters
-    {:type "object"
-     :properties
-     {:attribute_uri
-      {:type "string"
-       :description "The attribute URI, generally of the format '<http://syn.org/{data_standard}/{template}>', e.g. '<http://syn.org/gdc/sample>'."}}}
-    :required ["attribute_uri"]}})
-
-(def get_template_meta_spec
-  {:type "function"
-   :function
-   {:name "get_template_meta"
-    :description (str "Get information about an entity template such as its attributes (columns) and their order. Only available for GDC templates.")
-    :parameters
-    {:type "object"
-     :properties
-     {:template_uri
-      {:type "string"
-       :description "The template URI, generally of the format '<http://syn.org/{data_standard}/{template}>', e.g. '<http://syn.org/gdc/sample>'."}}}
-    :required ["template_uri"]}})
-
-(def list_standard_templates_spec
-  {:type "function"
-   :function
-   {:name "list_standard_templates"
-    :description (str "List the templates defined by a data standard. The template URIs are returned and 'get_template_meta' can be used to get further info about a specific template.")
-    :parameters
-    {:type "object"
-     :properties
-     {:standard_uri
-      {:type "string"
-       :enum ["<http://syn.org/gdc>"]
-       :description "The data standard URI, of the format '<http://syn.org/{data_standard}>', i.e. '<http://syn.org/gdc>'. Currently, only GDC standard is supported."}}}
-    :required ["standard_uri"]}})
-
-(def read_file_spec
-  {:type "function"
-   :function
-   {:name "read_file"
-    :description "Read text content accessible as a local file or via a URL. Files like Excel are *not* supported. Files larger than 50kb will not be read."
-    :parameters
-    {:type "object"
-     :properties
-     {:file {:type "string" 
-             :description "Local file path such as 'input/sample.csv' and 'examples/code.js', or URL such as 'https://raw.githubusercontent.com/.../data/sample-csv/organizations.csv'"}
-      }}
-    :required ["file"]}})
-
-(def summarize_file_spec
-  {:type "function"
-   :function
-   {:name "summarize_file"
-    :description "Get summary of the data within a csv file, such as columns present, unique values and value ranges. This can handle larger files."
-    :parameters
-    {:type "object"
-     :properties
-     {:file {:type "string"
-             :description "Local file path such as 'input/sample.csv'."}}}
-    :required ["file"]}})
-
-(def submit_data_spec
-  {:type "function"
-   :function
-   {:name "submit_data"
-    :description "CSV data or JSON defining the mapping/transform to be implemented (if so, conforms to a JSON schema)."
-    :parameters
-    {:type "object"
-     :properties
-     {:data
-      {:type "string"
-       :description "Data to be written to the file."}
-      :filename
-      {:type "string"
-       :description "File name, including the file extension."}}}
-    :required ["data" "filename"] }})
-
-(def tools
-  [find_matching_attribute_spec
-   get_attribute_meta_spec
-   get_template_meta_spec
-   list_standard_templates_spec
-   read_file_spec
-   summarize_file_spec
-   submit_data_spec
-   ])
-
-(def anthropic-tools (chat/convert-tools-for-anthropic tools true))
-
-;;;;;;;;;;;;;;;;;;;;;;
-;; Tool call wrappers
-;;;;;;;;;;;;;;;;;;;;;;
-
-(defn wrap-find-matching-attribute
-  [{:keys [attribute_uri]}]
-  (let [result (arachne/get-same-property attribute_uri)]
-    (mu/log ::find-matching-attribute :param attribute_uri) 
-    (if (or (nil? result) (empty? result))
-      {:result "No known matches were found."
-       :type :success}
-      {:result (str result)
-       :type :success})))
-
-(defn wrap-get-attribute-meta 
-  [{:keys [attribute_uri]}]
-  (let [result (arachne/describe-uri attribute_uri)]
-    (mu/log ::get-attribute-meta  :param attribute_uri)
-    (if (or (nil? result) (empty? result))
-      {:result "No result."
-       :type :success}
-      {:result (str result) 
-       :type :success})))
-
-(defn wrap-get-template-meta
-  [{:keys [template_uri]}]
-  (let [result (arachne/describe-template-columns template_uri)]
-    (if (or (nil? result) (empty? result))
-        {:result "No result."
-         :type :success}
-        {:result (str result)
-         :type :success})))
-
-(defn wrap-list-standard-templates
-  [{:keys [standard_uri]}] 
-  (let [result (arachne/list-templates standard_uri)]
-    (mu/log ::list-standard-templates  :param standard_uri)
-    (if (or (nil? result) (empty? result))
-        {:result "No result."
-         :type :success}
-        {:result (str result)
-         :type :success})))
-
-(defn wrap-read-file 
-  [{:keys [file]}]
-  (let [file-obj (java.io.File. file)
-         size-in-kb (/ (.length file-obj) 1024.0)]
-    (mu/log ::read-file  :filename file)
-     (if (< size-in-kb 10)
-       {:result (slurp file)
-        :type :success}
-       {:result "File is too large."
-        :type :error})))
-
-(defn wrap-submit-data 
-  [{:keys [data filename]}]
-  (let [file (spit filename data)]
-    (mu/log ::submit-data :filename filename :message data)
-    {:result "File stored."
-     :type :success}))
-
-(defn wrap-summarize-file
-  [{:keys [file]}] 
-  (let [result (cu/summarize-manifest file)]
-    (mu/log ::summarize-file  :filename file)
-    {:result (str result)
-     :type :success}))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Custom tool time
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn with-next-tool-call
-  "Applies logic for chaining certain tool calls. NOTE: Stub, not used."
-  [tool-result]
-  tool-result)
-
-(defn tool-time 
-  [tool-call]
-  (let [call-fn (get-in tool-call [:function :name])
-        args    (json/parse-string (get-in tool-call [:function :arguments]) true)]
-    (try
-      (let [result (case call-fn
-                     "find_matching_attribute"         (wrap-find-matching-attribute args)
-                     "get_attribute_meta"              (wrap-get-attribute-meta args)
-                     "get_template_meta"               (wrap-get-template-meta args)
-                     "list_standard_templates"         (wrap-list-standard-templates args)
-                     "read_file"                       (wrap-read-file args)
-                     "summarize_file"                  (wrap-summarize-file args)
-                     "submit_data"                (wrap-submit-data args)
-                     (throw (ex-info "Invalid tool function" {:tool call-fn})))]
-        (->
-         (if (map? result) (merge  {:tool call-fn} result) {:tool call-fn :result result})
-         (with-next-tool-call)))
-      (catch Exception e
-        {:tool   call-fn
-         :result (.getMessage e)
-         :type   :error
-         :error  true}))))
-
-(defn anthropic-tool-time
-  [tool-use]
-  (let [tool-call {:id       (:id tool-use)
-                   :type     "function"
-                   :function {:name      (:name tool-use)
-                              :arguments (json/generate-string (:input tool-use))}}]
-    (tool-time tool-call)))
-
-;;;;;;;;;;;;;;;;;;;;;
-;; Agent
-;;;;;;;;;;;;;;;;;;;;;
-
-(def role
-  (str 
-  "You are a data management agent who specializes in reviewing diverse data templates based on the CCDI standard and translating them to a desired common standard called **GDC**. "
-  "Your most common workflow consists of obtaining from the user the paths to one or more CSV templates of entity data that they need to transform to a target set of templates in the GDC standard. "
-  "For each CSV file with records of some entity type, you can use the 'read_file' tool to extract and see the entity data records. " 
-  ;; "Then you can use the tool load_into_working_graph to put the entity data into an OLAP knowledge graph, which is similar to using a data warehouse for data transformations. " 
-  "Given the input, you can query for information about matching target attributes and target templates to better understand specifications for the transformation. " 
-  "For example, given a CSV file called 'sample.csv' that may contain column 'sample_attribute_1', you can see whether 'sample_attribute_1' matches an attribute in the GDC standard, which GDC template it's used in, and acceptable values for the GDC version of the attribute. "
-  "You may retrieve the list of potential target templates in the GDC standard. Note that the inputs may not have a 1:1 match to the GDC templates, so not all GDC templates are output targets, only the relevant ones. "
-  "Once you have determined which GDC templates to output and how to translate the data sufficiently, either submit the csv data directly or use the mapping/transform specification schema (below), whichever is better. The output must contain/specify all columns in the target template!\n"
-  (slurp "resources/map_spec.json")
- ))
-
-(def openai-messages (atom [{:role "system" :content role}]))
-
-(def anthropic-messages (atom []))
-
-(def meta (atom {:system role}))
-
-(def OpenAIArachneAgent 
-  (chat/->OpenAIProvider "gpt-4o"
-                   openai-messages
-                   tools 
-                   tool-time
-                   meta))
-
-(def AnthropicArachneAgent
-  (chat/->AnthropicProvider "claude-3-5-sonnet-20241022" ;;"claude-3-7-sonnet-latest"  
-                            anthropic-messages
-                            anthropic-tools
-                            anthropic-tool-time
-                            meta))
+(def Arachne (agent/create-agent arachne-agent-config))
 
 (defn -main [] 
-  (setup)
-
-  (let [agent (if (= (@u :model-provider) "")
-                OpenAIArachneAgent 
-                AnthropicArachneAgent)]
-    
-    ;; Add shutdown hook to handle Ctrl+C
-    (.addShutdownHook (Runtime/getRuntime)
-      (Thread. (fn []
-                 (try
-                   ;; (chat/save-messages agent) ;; save based on config
-                   (catch Exception e
-                     (mu/log ::shutdown-error 
+  (.addShutdownHook 
+   (Runtime/getRuntime) 
+   (Thread. (fn [] 
+              (try
+                ;; (chat/save-messages agent) ;; save based on config 
+                (catch Exception e 
+                  (mu/log ::shutdown-error 
                              :msg "Error during shutdown" 
-                             :exception e)))
-                 (mu/log ::shutdown :msg "Goodbye!"))))
-    
-    (chat/chat agent)))
+                             :exception e))) 
+              (mu/log ::shutdown :msg "Goodbye!")))) 
+  (agent/chat Arachne))

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -9,6 +9,9 @@
             [clojure.string :as str]
             [com.brunobonacci.mulog :as mu]))
 
+(setup)
+(new-syn (@u :sat))
+
 (mu/start-publisher! {:type :simple-file
                       :filename "/tmp/mulog/events.edn"})
 
@@ -19,7 +22,7 @@
 
 (def syndi-agent-config 
   {:name "Syndi Data Platform Agent" 
-   :provider :openai ;; :anthropic ;; (= (@u :model-provider) "OpenAI")
+   :provider :openai ;; (@u :model-provider)
    :model "gpt-4o"
    :role (str
           "You are a data professional who masterfully uses tools and resources to help users with data product curation, informatics, and analysis tasks on the Synapse data platform. "
@@ -30,8 +33,6 @@
 (def Syndi (agent/create-agent syndi-agent-config))
 
 (defn -main [] 
-  (setup)
-  (new-syn (@u :sat))
   (.addShutdownHook ;; add shutdown hook for Ctrl+C 
    (Runtime/getRuntime) 
    (Thread. (fn [] 
@@ -42,4 +43,4 @@
                           :msg "Error during shutdown" 
                           :exception e)))
                  (mu/log ::shutdown :msg "Goodbye!")))) 
-    (agent/chat Syndi))
+  (agent/chat Syndi))

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -2,6 +2,7 @@
   (:gen-class)
   (:require [accent.state :refer [setup u]]
             [accent.chat :as agent]
+            [accent.tools :as tools]
             [curate.synapse :refer [new-syn]]
             [cheshire.core :as json]
             [clojure.string :as str]
@@ -15,14 +16,12 @@
 ;;             (when (not= (:sat old-state) (:sat new-state))
 ;;               (new-syn (:sat new-state)))))
 
-(new-syn (@u :sat))
-
 (def syndi-agent-config 
   {:name "Syndi Data Platform Agent" 
    :provider :openai ;; :anthropic ;; (= (@u :model-provider) "OpenAI")
    :model "gpt-4o"
    :role (str
-          "You are a data professional who masterfully uses tools and resources to help users with data product curation, informatics, and analysis tasks on the Synapse data platform."
+          "You are a data professional who masterfully uses tools and resources to help users with data product curation, informatics, and analysis tasks on the Synapse data platform. "
           "Your name is Syndi (pronounced like 'Cindy'), and you are highly intelligent, helpful, and pragmatic. "
           "You value being science-driven, accountable, growth-oriented, empathetic and inclusive, and radically collaborative.")
    :tools [:get-table-context :query-table :get-wiki :get-user-name]})
@@ -30,7 +29,8 @@
 (def Syndi (agent/create-agent syndi-agent-config))
 
 (defn -main [] 
-  (setup) 
+  (setup)
+  (new-syn (@u :sat))
   (.addShutdownHook ;; add shutdown hook for Ctrl+C 
    (Runtime/getRuntime) 
    (Thread. (fn [] 

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -1,366 +1,44 @@
 (ns agents.syndi
   (:gen-class)
   (:require [accent.state :refer [setup u]]
-            [accent.chat :as chat]
-            [curate.synapse :refer [new-syn syn curate-dataset create-folder get-table-sample get-entity-wiki get-entity-schema get-user-name query-table set-annotations]]
-            [agents.extraction :refer [call-extraction-agent call_extraction_agent_spec]]
+            [accent.chat :as agent]
+            [curate.synapse :refer [new-syn]]
             [cheshire.core :as json]
             [clojure.string :as str]
             [com.brunobonacci.mulog :as mu]))
 
-;; Set up
+(mu/start-publisher! {:type :simple-file
+                      :filename "/tmp/mulog/events.edn"})
 
-(add-watch u :syn-client-watcher
-           (fn [_ _ old-state new-state]
-             (when (not= (:sat old-state) (:sat new-state))
-               (new-syn (:sat new-state)))))
+;;(add-watch u :syn-client-watcher
+;;           (fn [_ _ old-state new-state]
+;;             (when (not= (:sat old-state) (:sat new-state))
+;;               (new-syn (:sat new-state)))))
 
 (new-syn (@u :sat))
 
-;; Stores intermediate and final results for curated data products such as datasets, figures, etc.
-(defonce products
-  (atom nil))
+(def syndi-agent-config 
+  {:name "Syndi Data Platform Agent" 
+   :provider :openai ;; :anthropic ;; (= (@u :model-provider) "OpenAI")
+   :model "gpt-4o"
+   :role (str
+          "You are a data professional who masterfully uses tools and resources to help users with data product curation, informatics, and analysis tasks on the Synapse data platform."
+          "Your name is Syndi (pronounced like 'Cindy'), and you are highly intelligent, helpful, and pragmatic. "
+          "You value being science-driven, accountable, growth-oriented, empathetic and inclusive, and radically collaborative.")
+   :tools [:get-table-context :query-table :get-wiki :get-user-name]})
 
-;;;;;;;;;;;;;;;;;;;;;
-;; Tool defs
-;;;;;;;;;;;;;;;;;;;;;
-
-(def curate_dataset_spec
-  {:type "function"
-   :function
-   {:name "curate_dataset"
-    :description "Use to curate an existing dataset on Synapse; retrieve dataset meta given a scope id and, optionally, a manifest id."
-    :parameters
-    {:type "object"
-     :properties
-     {:scope_id
-      {:type "string"
-       :description "The scope id to use, e.g. 'syn12345678'"}
-      :asset_view
-      {:type "string"
-       :description "The asset view id to use, which should have pattern syn[0-9]+"}
-      :manifest_id
-      {:type "string"
-       :description (str "The manifest id, e.g. 'syn224466889'."
-                         "While the manifest can be automatically discovered in most cases,"
-                         " when not in the expected location the id will need to be provided by the user.")}}}
-    :required ["scope_id" "asset_view"] }})
-
-(def stage_curated_spec
-  {:type "function"
-   :function
-   {:name "stage_curated"
-    :description "Use to stage a curated and enhanced data product for user review and approval."
-    :parameters
-    {:type "object"
-     :properties
-     {:product_type {:type "string"
-                     :enum ["dataset"]
-                     :description "Type of curated product"}
-      :metadata {:type "string"
-                :description "Metadata content as a JSON string adhering to the data product schema."}}}
-    :required ["product_type" "metadata"]}})
-
-(def commit_spec
-  {:type "function"
-   :function
-   {:name "commit"
-    :description (str "Add new or updated metadata for an entity (data product) into the Synapse platform.")
-    :parameters
-    {:type "object"
-     :properties
-     {:data
-      {:type "string"
-       :description "JSON string representing the entity."}
-      :entity_id
-      {:type "string"
-       :description "Id of existing entity to update, or omit to add metadata for a new entity. If omitted, use `collection_id` and `product_name`."}
-      :collection_id
-      {:type "string"
-       :description "(Only for new entities where `entity_id` does not exist) Provide the id of a Synapse collection where changes can be created."}
-      :product_name
-      {:type "string"
-       :description "(Only for new entities where `entity_id` does not exist) Suggested name or title for the entity"}}}
-    :required ["data"] }})
-
-(def get_table_context_spec
-  {:type "function"
-   :function
-   {:name "get_table_context"
-    :description (str "Use this to first confirm the availability of a Synapse table and its queryable fields (schema). "
-                      "This will also return useful table documentation if available. "
-                      "In some cases, the user may not have table access or the available fields may be insufficient for the question. "
-                      "Use the returned table context to answer a general question about the table, construct a query, or explain why the user question may not be feasible.")
-    :parameters
-    {:type "object"
-     :properties
-     {:table_id
-      {:type "string"
-       :description (str "Id of the table to use, which should be specified by the user.")}}}
-    :required ["table_id"]}})
-
-(def get_entity_wiki_spec
-  {:type "function"
-   :function
-   {:name "get_entity_wiki"
-    :description "Get the Wiki page, if it exists, for a Synapse entity."
-    :parameters
-    {:type "object"
-     :properties
-     {:id
-      {:type "string"
-       :description "Synapse entity id, e.g. 'syn12345678'"}}}
-    :required ["id"] }})
-
-(def get_user_name_spec
-  {:type "function"
-   :function
-   {:name "get_user_name"
-    :description "Get a user name given a user id (results depend on how the user filled out this field, and in some cases may contain first name only or may be blank)."
-    :parameters
-    {:type "object"
-     :properties
-     {:userid {:type "number"
-               :description "Ids are integers, e.g. 273960."}}}}})
-
-(def query_table_spec
-  {:type "function"
-   :function
-   {:name "query_table"
-    :description (str "Use to query table with SQL to help answer a user question; "
-                      "query should include only queryable fields; "
-                      "only a subset of valid SQL is allowed -- do not include update clauses.")
-    :parameters
-    {:type "object"
-     :properties
-     {:table_id {:type "string"
-                 :description "Table id, e.g. 'syn5464523"}
-      :query {:type "string"
-              :description "A valid SQL query."}}}}})
-
-(def call_viz_agent_spec
-  {:type "function"
-   :function
-   {:name "call_viz_agent"
-    :description "Use visualization agent to plot data in the UI. Data provided must conform to the Vega-Lite specification"
-    :parameters
-    {:type "object"
-     :properties
-     {:request {:type "string"
-                :description "A summary of the user's visualization intent to help correct or enhance the output if needed and for logging purposes."}
-      :data {:type "string"
-             :description "JSON parseable string of the vis data in the Vega-Lite spec. Example: `{\"data\":{\"values\":[{\"a\":\"C\",\"b\":2},{\"a\":\"C\",\"b\":7},{\"a\":\"C\",\"b\":4},{\"a\":\"D\",\"b\":1},{\"a\":\"D\",\"b\":2},{\"a\":\"D\",\"b\":6},{\"a\":\"E\",\"b\":8},{\"a\":\"E\",\"b\":4},{\"a\":\"E\",\"b\":7}]},\"mark\":\"bar\",\"encoding\":{\"y\":{\"field\":\"a\",\"type\":\"nominal\"},\"x\":{\"aggregate\":\"average\",\"field\":\"b\",\"type\":\"quantitative\",\"axis\":{\"title\":\"Average of b\"}}}}`"}}}}})
-
-(def call_knowledgebase_agent_spec
-  {:type "function"
-  :function 
-  {:name "call_knowledgebase_agent"
-   :description "Ask specialized agent to query a separate knowledgebase of project configurations and reference data standards"
-   :parameters
-   {:type "object"
-   :properties
-   {:request {:type "string"
-              :description (str "A clear question or request to help the agent perform the query, such as: " 
-                           "'What is the asset view for the DCC called NF-OSI?' or "
-                           "'Give me the DCC-specific definition for the column named for the HTAN DCC' or"
-                           "'Does an ImagingAssayTemplate exist?'")}}}}})
-
-(def tools
-  [;;curate_dataset_spec ;; make more flexible
-   commit_spec
-   stage_curated_spec
-   get_table_context_spec
-   query_table_spec
-   get_entity_wiki_spec
-   get_user_name_spec
-   call_extraction_agent_spec
-   call_viz_agent_spec
-   ;; call_knowledgebase_agent_spec ;; being refactored
-   ])
-
-(def anthropic-tools (chat/convert-tools-for-anthropic tools true))
-
-;;;;;;;;;;;;;;;;;;;;;;
-;; Tool call wrappers
-;;;;;;;;;;;;;;;;;;;;;;
-
-;; Wrappers implement further abstractions, do checking as needed of the return, 
-;; returns a consistent map with a :result key, which is the result of the tool call,
-;; perform any side-effecting actions to save output data outside of messages, 
-;; and optionally a :ui key, which is a map of UI elements to be rendered in the UI.
-
-(defn wrap-curate-dataset
-  "Implement pipeline and prompt engineering to coordinate curation: 1) get dataset schema, 2) call curate_dataset for some preprocessing, 
-  3) store dataset intermediate for reference 4) return various data sources with appropriate prompting"
-  [{:keys [scope_id asset_view]}]
-  (let [schema (get-entity-schema @syn scope_id)]
-    (if (nil? schema)
-      {:result "Entity schema is not available. Curation cannot proceed without a valid schema."
-       :type :error}
-      (let [result (curate-dataset @syn scope_id asset_view)]
-        (if (= :success (result :type))
-          (do 
-            (swap! products assoc-in [:dataset :intermediate] result)
-            {:result (str "Info: Schema for data product and initial data retrieved below.\n"
-                          "Instructions: Carefully review the properties in the target schema and describe the data product according to the schema before staging for review. "
-                          "If 'description', 'comments' or similar field is present, write an informative description tailored for the entity type. "
-                          "For example, for a dataset entity, highlight things like interesting features, number or types of samples to help others consume the curated product. "
-                          "Target schema:\n" schema "\n\nInitial data:\n" (result :result))
-             :type :success})
-          result)))))
-
-(defn wrap-stage-curated
-  "Stage the curated entity by displaying it to the user."
-  [{:keys [product_type metadata]}]
-  (let [curated (json/parse-string metadata)]
-    (swap! products assoc-in [(keyword product_type) :staging] curated)
-    {:result "Curated entity has been staged for review. Confirm with user if it should be stored using `commit`."
-     :data curated ;; TODO: validation
-     :dataspec "dataset"
-     :type :success}))
-
-(defn wrap-commit
-  "Store the data as annotations on an existing entity, or create a new entity within a storage scope first if needed.
-  TODO: ability to use create-file instead of create-folder"
-  [{:keys [data entity_id collection_id product_name]}]
-  (let [ann-map (json/parse-string data)
-        id (if entity_id entity_id (create-folder @syn product_name entity_id))
-        response (set-annotations @syn id ann-map)]
-    (println "Metadata stored on/within" collection_id entity_id)
-    (if (= 200 (:status response))
-      {:result "Committed successfully."
-       :type :success}
-      {:result (str "Failed to store, server returned status " (:status response))
-       :type :error})))
-
-(defn wrap-get-table-context
-  "Combine retrieval of table schema and Wiki doc as table context"
-  [{:keys [table_id]}]
-  (let [schema (get-table-sample @syn table_id)
-        doc (get-entity-wiki @syn table_id)]
-        ;;table-schema (as-schema cols (@u :dcc))] ;; previous impl using kg
-    {:result (str {:schema schema :doc doc })
-     :type :success}))
-
-(defn wrap-query-table
-  [{:keys [table_id query]}]
-  {:result (str (query-table @syn table_id query))
-   :type   :success})
-
-(defn wrap-get-entity-wiki
-  [{:keys [id]}]
-  {:result (get-entity-wiki @syn id)
-   :type   :success})
-
-(defn wrap-get-user-name
-  [{:keys [userid]}]
-  {:result (str (get-user-name @syn (str userid)))
-   :type   :success})
-
-(defn wrap-call-extraction-agent
-  [{:keys [input input_representation json_schema json_schema_representation]}] 
-  (-> (call-extraction-agent input input_representation json_schema json_schema_representation) 
-      (chat/request-openai-completions :string) 
-      (chat/get-first-message-content)))
-
-(defn wrap-call-viz-agent
-  [{:keys [request data]}]
-  {:result (str "Visualization added.")
-   :data (json/parse-string data) ;; TODO: validation
-   :dataspec "vega-lite"
-   :type :success})
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Custom tool time
-;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn with-next-tool-call
-  "Applies logic for chaining certain tool calls. Input should be result from `tool-time`
-  Currently, stage_curated should be forced after curate_dataset only under certain return types."
-  [tool-result]
-  (if (and (= "curate_dataset" (tool-result :tool)) (= :success (tool-result :type)))
-    (assoc tool-result :next-tool-call "stage_curated")
-    tool-result))
-
-(defn tool-time 
-  [tool-call]
-  (let [call-fn (get-in tool-call [:function :name])
-        args    (json/parse-string (get-in tool-call [:function :arguments]) true)]
-    (try
-      (let [result (case call-fn
-                     "curate_dataset"         (wrap-curate-dataset args)
-                     "stage_curated"          (wrap-stage-curated args)
-                     "commit"                 (wrap-commit args)
-                     "get_table_context"      (wrap-get-table-context args)
-                     "query_table"            (wrap-query-table args)
-                     "get_entity_wiki"        (wrap-get-entity-wiki args)
-                     "get_user_name"          (wrap-get-user-name args)
-                     "call_extraction_agent"  (wrap-call-extraction-agent args)
-                     "call_viz_agent"         (wrap-call-viz-agent args)
-                     (throw (ex-info "Invalid tool function" {:tool call-fn})))]
-        (->
-         (if (map? result) (merge  {:tool call-fn} result) {:tool call-fn :result result})
-         (with-next-tool-call)))
-      (catch Exception e
-        {:tool   call-fn
-         :result (.getMessage e)
-         :type   :error
-         :error  true}))))
-
-(defn anthropic-tool-time
-  [tool-use]
-  (let [tool-call {:id       (:id tool-use)
-                   :type     "function"
-                   :function {:name      (:name tool-use)
-                              :arguments (json/generate-string (:input tool-use))}}]
-    (tool-time tool-call)))
-
-;;;;;;;;;;;;;;;;;;;;;
-;; Agent
-;;;;;;;;;;;;;;;;;;;;;
-
-(def role
-  (str 
-  "You are a data professional who masterfully uses tools and resources at hand to help users with data product curation, informatics, and analysis tasks on the Synapse platform."
-  "Your name is Syndi (pronounced like 'Cindy'), and you see yourself as highly intelligent, helpful, and pragmatic. "
-  "You value being science-driven, accountable, growth-oriented, empathetic and inclusive, and radically collaborative."))
-
-(def openai-messages (atom [{:role "system" :content role}]))
-
-(def anthropic-messages (atom []))
-
-(def meta (atom {:system role}))
-
-(def OpenAISyndiAgent 
-  (chat/->OpenAIProvider "gpt-4o" 
-                   openai-messages
-                   tools 
-                   tool-time
-                   meta))
-
-(def AnthropicSyndiAgent 
-  (chat/->AnthropicProvider "claude-3-7-sonnet-latest" 
-                      anthropic-messages
-                      anthropic-tools 
-                      anthropic-tool-time
-                      meta))
+(def Syndi (agent/create-agent syndi-agent-config))
 
 (defn -main [] 
-  (setup)
-
-  (let [agent (if (= (@u :model-provider) "OpenAI")
-                OpenAISyndiAgent 
-                AnthropicSyndiAgent)]
-    
-    ;; Add shutdown hook to handle Ctrl+C
-    (.addShutdownHook (Runtime/getRuntime)
-      (Thread. (fn []
-                 (try
-                   ;; (chat/save-messages agent) ;; save based on config
-                   (catch Exception e
-                     (mu/log ::shutdown-error 
-                             :msg "Error during shutdown" 
-                             :exception e)))
-                 (mu/log ::shutdown :msg "Goodbye!"))))
-    
-    (chat/chat agent)))
+  (setup) 
+  (.addShutdownHook ;; add shutdown hook for Ctrl+C 
+   (Runtime/getRuntime) 
+   (Thread. (fn [] 
+              (try
+                ;; (agent/save-messages Syndi) ;; save based on config 
+                (catch Exception e 
+                  (mu/log ::shutdown-error 
+                          :msg "Error during shutdown" 
+                          :exception e)))
+                 (mu/log ::shutdown :msg "Goodbye!")))) 
+    (agent/chat Syndi))

--- a/src/agents/syndi.clj
+++ b/src/agents/syndi.clj
@@ -2,6 +2,7 @@
   (:gen-class)
   (:require [accent.state :refer [setup u]]
             [accent.chat :as agent]
+            [accent.registry :as registry]
             [accent.tools :as tools]
             [curate.synapse :refer [new-syn]]
             [cheshire.core :as json]
@@ -24,7 +25,7 @@
           "You are a data professional who masterfully uses tools and resources to help users with data product curation, informatics, and analysis tasks on the Synapse data platform. "
           "Your name is Syndi (pronounced like 'Cindy'), and you are highly intelligent, helpful, and pragmatic. "
           "You value being science-driven, accountable, growth-oriented, empathetic and inclusive, and radically collaborative.")
-   :tools [:get-table-context :query-table :get-wiki :get-user-name]})
+   :tools #{:get-table-context :query-table :get-wiki :get-user-name}})
 
 (def Syndi (agent/create-agent syndi-agent-config))
 
@@ -35,7 +36,7 @@
    (Runtime/getRuntime) 
    (Thread. (fn [] 
               (try
-                ;; (agent/save-messages Syndi) ;; save based on config 
+                (agent/save-messages Syndi) ;; save based on config
                 (catch Exception e 
                   (mu/log ::shutdown-error 
                           :msg "Error during shutdown" 

--- a/src/agents/vanilla.clj
+++ b/src/agents/vanilla.clj
@@ -1,0 +1,19 @@
+(ns agents.vanilla
+  (:gen-class)
+  (:require [accent.state :refer [setup u]]
+            [accent.chat :as agent]
+            [com.brunobonacci.mulog :as mu]))
+
+;;=========================================
+;; Vanilla Agent
+;;=========================================
+
+(def vanilla-agent-config
+  {:name "Vanilla Agent"
+   :provider :openai
+   :model "gpt-4o"
+   :role (str
+          "You are a data professional who masterfully uses tools and resources to help users with data product curation, informatics, and analysis tasks on the Synapse data platform."
+          "Your name is Syndi (pronounced like 'Cindy'), and you are highly intelligent, helpful, and pragmatic. "
+          "You value being science-driven, accountable, growth-oriented, empathetic and inclusive, and radically collaborative.")
+   :tools []})

--- a/src/agents/vanilla.clj
+++ b/src/agents/vanilla.clj
@@ -4,10 +4,6 @@
             [accent.chat :as agent]
             [com.brunobonacci.mulog :as mu]))
 
-;;=========================================
-;; Vanilla Agent
-;;=========================================
-
 (def vanilla-agent-config
   {:name "Vanilla Agent"
    :provider :openai
@@ -17,3 +13,4 @@
           "Your name is Syndi (pronounced like 'Cindy'), and you are highly intelligent, helpful, and pragmatic. "
           "You value being science-driven, accountable, growth-oriented, empathetic and inclusive, and radically collaborative.")
    :tools []})
+


### PR DESCRIPTION
Closes #122 by creating a global tools registry. Prompts registry also somewhat implemented but not yet tested. Benefits:

1. Centralized management: All tools are registered in one place; easier to discover what tools are available; consistent tool interface across agents
2. Create agents by composition: Easier to create specialized agents with different tool sets, but tools can also now be shared across multiple agents.
3. Better organization: Tools are better organized with category and permissions annotations, with some concept of dependency tracking.
4. Cleaner provider interfaces: Adds automatic conversion between OpenAI and Anthropic formats; universal tool dispatcher; clear way to add new providers.
5. Development: add validation and other checks for tool definitions and the registry itself.

There is also substantial setting up for MCP server features (#138).