### PR TITLE
Fix missing setup with updated agent config

### DIFF
--- a/src/server/core.clj
+++ b/src/server/core.clj
@@ -3,6 +3,7 @@
   (:require [accent.state :refer [setup u]]
             [accent.chat :refer [stream-response save-messages]]
             [agents.syndi :refer [Syndi]]
+            [curate.synapse :refer [new-syn]] ;; Syndi needs Synapse client
             [org.httpkit.server :as httpkit]
             [compojure.core :refer [defroutes GET]]
             [compojure.route :as route]
@@ -70,6 +71,7 @@
 
 (defn start-server []
   (setup :ui :web)
+  (new-syn (@u :sat))
   (swap! u assoc :stream true)
   (let [server (httpkit/run-server app-routes {:port 3000})]
     (browse-url "http://localhost:3000")


### PR DESCRIPTION
Given the revised approach to configure/create agents after #148, we must remember to set up any dependencies for tool use as part of client setup (in this case, Synapse token). This was a bug when Syndi agent is started with web app interface only, and not the terminal interface.